### PR TITLE
fix: lucide-react v1 で削除された Github アイコンをインライン SVG 化

### DIFF
--- a/app/src/routes/WorkDetail.tsx
+++ b/app/src/routes/WorkDetail.tsx
@@ -1,6 +1,21 @@
 import { Link, useParams } from 'react-router-dom';
-import { ArrowLeft, ExternalLink, Github, Play } from 'lucide-react';
+import { ArrowLeft, ExternalLink, Play } from 'lucide-react';
 import { CATEGORY_LABEL, findWork } from '../lib/works';
+
+function GithubMark({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.57.1.78-.25.78-.55 0-.27-.01-.99-.02-1.95-3.2.7-3.87-1.54-3.87-1.54-.52-1.32-1.28-1.67-1.28-1.67-1.05-.72.08-.71.08-.71 1.16.08 1.77 1.2 1.77 1.2 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.56-.29-5.25-1.28-5.25-5.7 0-1.26.45-2.29 1.19-3.1-.12-.3-.52-1.47.11-3.06 0 0 .97-.31 3.18 1.18.92-.26 1.91-.39 2.9-.39.99 0 1.98.13 2.9.39 2.21-1.49 3.18-1.18 3.18-1.18.63 1.59.23 2.76.11 3.06.74.81 1.19 1.84 1.19 3.1 0 4.43-2.69 5.41-5.26 5.69.41.35.78 1.04.78 2.1 0 1.52-.01 2.75-.01 3.12 0 .3.21.66.79.55C20.22 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z" />
+    </svg>
+  );
+}
 
 const STATUS_COPY: Record<string, string> = {
   new: 'Freshly dropped quest',
@@ -75,7 +90,7 @@ export function WorkDetail() {
                 rel="noreferrer"
                 className="pixel-button pixel-button--ghost"
               >
-                <Github size={14} /> Code
+                <GithubMark size={14} /> Code
               </a>
             )}
           </div>


### PR DESCRIPTION
## 概要
Dependabot #6 で lucide-react が **0.546 → 1.8** に上がった際、ブランド系アイコン (Github 等) がライブラリから削除されました。その結果、main 上で

- `Lint`: `TS2724: Module '"lucide-react"' has no exported member 'Github'`
- `Playwright Smoke`: 同じ理由で `npm run build` が失敗
- `Test`: Vitest は build を通さないので緑のまま

となっていました。

## 修正内容
- `app/src/routes/WorkDetail.tsx` の `Github` import を削除
- 代わりに同ファイルに `GithubMark` コンポーネント (24x24 viewBox のインライン SVG) を追加し、Code ボタンの左に描画
- 小さな依存 (simple-icons / react-icons) を追加しないための判断

## テスト
- [x] `npm run build` — クリーンビルド
- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 1 file / 3 tests pass
- [x] `npx playwright test` — 6/6 smoke specs green
- [ ] CI 上でも全チェックが緑になること