### PR TITLE
fix(topnav): プレースホルダだった Resume/settings/account_circle を削除 (#25)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ coverage/
 # Playwright
 playwright-report/
 test-results/
+
+# Claude Code (local agent state; not shared with repo)
+.claude/

--- a/app/src/components/layout/TopNav.tsx
+++ b/app/src/components/layout/TopNav.tsx
@@ -15,7 +15,7 @@ export function TopNav() {
           Shiyow
         </NavLink>
 
-        <nav className="hidden md:flex items-center gap-8">
+        <nav className="flex items-center gap-8">
           {LINKS.map((link) => (
             <NavLink
               key={link.to}
@@ -35,30 +35,6 @@ export function TopNav() {
             </NavLink>
           ))}
         </nav>
-
-        <div className="flex items-center gap-4">
-          <button
-            type="button"
-            className="pixel-button hidden sm:inline-flex"
-            aria-label="Download resume"
-          >
-            Resume
-          </button>
-          <div className="flex gap-2 text-tertiary">
-            <span
-              className="material-symbols-outlined cursor-pointer hover:text-primary"
-              aria-hidden
-            >
-              settings
-            </span>
-            <span
-              className="material-symbols-outlined cursor-pointer hover:text-primary"
-              aria-hidden
-            >
-              account_circle
-            </span>
-          </div>
-        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
Closes #25

## 概要
TopNav 右側に置かれていた 3 要素 (Resume ボタン / settings アイコン / account_circle アイコン) は Templates/design からコピーしたままのプレースホルダで、いずれも `onClick` / `href` 未設定で何も動作していませんでした。ポートフォリオサイトとして不要なため削除します。

## 変更
- `app/src/components/layout/TopNav.tsx`: 右側 div ブロックを削除、ナビの `hidden md:flex` も外してモバイルでも同じレイアウトに
- `.gitignore`: `.claude/` (ローカルエージェント状態) を除外

## 今後
- ハンバーガーメニュー化 (#26)
- スクロール時ヘッダー固定修正 (#27)
- サイト全体のアニメ強化 (#28)
を順に続けます。

## テスト
- [x] `npm run build` / `lint` / `test` すべて pass
- [x] Playwright スモーク 6/6 pass (ローカル確認)
- [ ] CI 上で全チェック緑