### PR TITLE
feat(topnav): ナビをハンバーガーメニューに集約 (#26)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ coverage/
 # Playwright
 playwright-report/
 test-results/
+
+# Claude Code (local agent state; not shared with repo)
+.claude/

--- a/app/e2e/smoke.spec.ts
+++ b/app/e2e/smoke.spec.ts
@@ -39,4 +39,22 @@ test.describe('Smoke', () => {
     await page.goto('/no-such-page');
     await expect(page.getByRole('heading', { level: 1, name: '404' })).toBeVisible();
   });
+
+  test('hamburger menu opens, navigates, and closes', async ({ page }) => {
+    await page.goto('/');
+    const trigger = page.locator('button[aria-controls="site-menu-panel"]');
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    const panel = page.getByRole('dialog', { name: /site navigation/i });
+    await expect(panel).toBeVisible();
+
+    const aboutLink = panel.getByRole('link', { name: /about/i });
+    await expect(aboutLink).toBeVisible();
+    await aboutLink.click();
+
+    await expect(page).toHaveURL(/\/about$/);
+    await expect(page.getByRole('dialog', { name: /site navigation/i })).toBeHidden();
+  });
 });

--- a/app/src/components/layout/TopNav.tsx
+++ b/app/src/components/layout/TopNav.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef, useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import { AnimatePresence, motion } from 'motion/react';
 
 const LINKS = [
   { to: '/', label: 'Home', end: true },
@@ -8,34 +10,165 @@ const LINKS = [
 ];
 
 export function TopNav() {
-  return (
-    <header className="sticky top-0 z-50 bg-surface/90 backdrop-blur-sm border-b-4 border-tertiary shadow-[0_4px_0_0_rgba(126,87,46,0.2)]">
-      <div className="flex justify-between items-center w-full px-6 py-4 max-w-[1440px] mx-auto">
-        <NavLink to="/" className="text-2xl font-black text-tertiary tracking-tighter uppercase">
-          Shiyow
-        </NavLink>
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
-        <nav className="flex items-center gap-8">
-          {LINKS.map((link) => (
-            <NavLink
-              key={link.to}
-              to={link.to}
-              end={link.end}
-              className={({ isActive }) =>
-                [
-                  'font-bold uppercase tracking-widest text-sm transition-transform duration-100',
-                  'hover:-translate-y-[2px]',
-                  isActive
-                    ? 'text-primary border-b-4 border-primary pb-1'
-                    : 'text-tertiary hover:text-secondary',
-                ].join(' ')
-              }
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const firstLink = panelRef.current?.querySelector<HTMLAnchorElement>('a');
+    firstLink?.focus();
+
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = '';
+      previouslyFocused?.focus?.();
+    };
+  }, [open]);
+
+  return (
+    <>
+      <header className="sticky top-0 z-50 bg-surface/90 backdrop-blur-sm border-b-4 border-tertiary shadow-[0_4px_0_0_rgba(126,87,46,0.2)]">
+        <div className="flex justify-between items-center w-full px-6 py-4 max-w-[1440px] mx-auto">
+          <NavLink to="/" className="text-2xl font-black text-tertiary tracking-tighter uppercase">
+            Shiyow
+          </NavLink>
+
+          <button
+            ref={triggerRef}
+            type="button"
+            aria-label={open ? 'Close menu' : 'Open menu'}
+            aria-expanded={open}
+            aria-controls="site-menu-panel"
+            onClick={() => setOpen((v) => !v)}
+            className="flex items-center gap-3 pixel-border bg-tertiary-container px-4 py-2 font-black uppercase tracking-widest text-sm text-on-tertiary-container hover:-translate-y-0.5 transition-transform"
+          >
+            <HamburgerIcon open={open} />
+            <span className="hidden sm:inline">{open ? 'Close' : 'Menu'}</span>
+          </button>
+        </div>
+      </header>
+
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div
+              key="backdrop"
+              aria-hidden
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              onClick={() => setOpen(false)}
+              className="fixed inset-0 z-[60] bg-on-surface/40 backdrop-blur-[2px]"
+            />
+
+            <motion.div
+              key="panel"
+              ref={panelRef}
+              id="site-menu-panel"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Site navigation"
+              initial={{ x: '100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '100%' }}
+              transition={{ type: 'tween', duration: 0.35, ease: [0.2, 0.8, 0.2, 1] }}
+              className="fixed top-0 right-0 bottom-0 z-[61] w-[min(22rem,92vw)] bg-surface-container-high border-l-4 border-tertiary shadow-[-4px_0_0_0_rgba(126,87,46,0.25)] flex flex-col"
             >
-              {link.label}
-            </NavLink>
-          ))}
-        </nav>
-      </div>
-    </header>
+              <div className="flex justify-between items-center px-6 py-4 border-b-4 border-tertiary bg-tertiary-container">
+                <span className="font-black uppercase tracking-widest text-xs text-on-tertiary-container">
+                  Menu
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  aria-label="Close menu"
+                  className="font-black uppercase tracking-widest text-xs text-tertiary hover:text-primary"
+                >
+                  Close
+                </button>
+              </div>
+
+              <nav className="flex-1 overflow-auto px-6 py-8">
+                <ul className="space-y-2">
+                  {LINKS.map((link, idx) => (
+                    <motion.li
+                      key={link.to}
+                      initial={{ opacity: 0, x: 24 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: 24 }}
+                      transition={{
+                        delay: 0.08 + idx * 0.06,
+                        duration: 0.3,
+                        ease: [0.2, 0.8, 0.2, 1],
+                      }}
+                    >
+                      <NavLink
+                        to={link.to}
+                        end={link.end}
+                        onClick={() => setOpen(false)}
+                        className={({ isActive }) =>
+                          [
+                            'flex items-center gap-3 w-full px-4 py-3 pixel-border-thin bg-surface-container-lowest',
+                            'font-black uppercase tracking-widest text-lg transition-transform',
+                            'hover:-translate-y-0.5 hover:bg-primary hover:text-on-primary',
+                            isActive
+                              ? 'text-primary border-primary shadow-[4px_4px_0_0_var(--color-primary)]'
+                              : 'text-tertiary',
+                          ].join(' ')
+                        }
+                      >
+                        <span className="text-primary font-pixel text-xs">{`0${idx + 1}`}</span>
+                        <span>{link.label}</span>
+                      </NavLink>
+                    </motion.li>
+                  ))}
+                </ul>
+              </nav>
+
+              <footer className="px-6 py-4 border-t-4 border-tertiary bg-surface-container text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+                shiyow.dev · 16-Bit Atélier
+              </footer>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}
+
+function HamburgerIcon({ open }: { open: boolean }) {
+  return (
+    <span aria-hidden className="relative block w-5 h-5">
+      <motion.span
+        className="absolute left-0 right-0 h-[3px] bg-on-tertiary-container"
+        style={{ top: '20%' }}
+        animate={open ? { rotate: 45, top: '50%', translateY: '-50%' } : { rotate: 0, top: '20%' }}
+        transition={{ duration: 0.25 }}
+      />
+      <motion.span
+        className="absolute left-0 right-0 h-[3px] bg-on-tertiary-container top-1/2 -translate-y-1/2"
+        animate={open ? { opacity: 0 } : { opacity: 1 }}
+        transition={{ duration: 0.15 }}
+      />
+      <motion.span
+        className="absolute left-0 right-0 h-[3px] bg-on-tertiary-container"
+        style={{ top: '80%' }}
+        animate={open ? { rotate: -45, top: '50%', translateY: '-50%' } : { rotate: 0, top: '80%' }}
+        transition={{ duration: 0.25 }}
+      />
+    </span>
   );
 }

--- a/app/src/components/layout/TopNav.tsx
+++ b/app/src/components/layout/TopNav.tsx
@@ -15,7 +15,7 @@ export function TopNav() {
           Shiyow
         </NavLink>
 
-        <nav className="hidden md:flex items-center gap-8">
+        <nav className="flex items-center gap-8">
           {LINKS.map((link) => (
             <NavLink
               key={link.to}
@@ -35,30 +35,6 @@ export function TopNav() {
             </NavLink>
           ))}
         </nav>
-
-        <div className="flex items-center gap-4">
-          <button
-            type="button"
-            className="pixel-button hidden sm:inline-flex"
-            aria-label="Download resume"
-          >
-            Resume
-          </button>
-          <div className="flex gap-2 text-tertiary">
-            <span
-              className="material-symbols-outlined cursor-pointer hover:text-primary"
-              aria-hidden
-            >
-              settings
-            </span>
-            <span
-              className="material-symbols-outlined cursor-pointer hover:text-primary"
-              aria-hidden
-            >
-              account_circle
-            </span>
-          </div>
-        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
Closes #26

**依存:** このブランチは #29 (fix/topnav-remove-placeholders) の後に main 取り込み想定ですが、現在は main から直接派生しており単独でマージ可能です。#29 が先にマージされても競合なし (対象ファイルは被るが後続の変更が前の差分を完全に包含)。

## 概要
Home / About / Gallery / Changelog のリンクをハンバーガーメニューに集約しました。参考: https://yharuto.dev/

## 動作
- 右上のボタン (3本線) クリックで右から 22rem 幅のパネルが slide-in
- 中のリンクは 60ms 間隔の stagger で順次フェードイン
- アイコン自身は 3本線 ↔ × への変形アニメ
- バックドロップクリック / Escape / リンククリックで閉じる
- 最初のリンクにフォーカスが当たり、body スクロールを固定

## アクセシビリティ
- `aria-expanded` / `aria-controls="site-menu-panel"`
- パネルは `role="dialog"` + `aria-modal="true"` + `aria-label`
- Escape キーで閉じた時に開閉ボタンにフォーカスが戻る

## テスト
- Playwright に 'ハンバーガー開閉 + 遷移' を追加。全 7 テスト緑
- build / lint / vitest すべて pass

## スクリーンショット
dev server で動作確認済。

## 次
- #27 (スクロール時にヘッダー消える) を続けて修正
- #28 (サイト全体アニメーション強化)