### PR TITLE
feat(motion): サイト全体のアニメーション強化 (#28)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ coverage/
 # Playwright
 playwright-report/
 test-results/
+
+# Claude Code (local agent state; not shared with repo)
+.claude/

--- a/app/e2e/smoke.spec.ts
+++ b/app/e2e/smoke.spec.ts
@@ -40,6 +40,18 @@ test.describe('Smoke', () => {
     await expect(page.getByRole('heading', { level: 1, name: '404' })).toBeVisible();
   });
 
+  test('header stays pinned to the top while scrolling', async ({ page }) => {
+    await page.goto('/');
+    const header = page.locator('header').first();
+    await expect(header).toBeVisible();
+    const initialBox = await header.boundingBox();
+    await page.evaluate(() => window.scrollTo(0, 1200));
+    await page.waitForTimeout(200);
+    await expect(header).toBeVisible();
+    const scrolledBox = await header.boundingBox();
+    expect(scrolledBox?.y).toBeLessThanOrEqual((initialBox?.y ?? 0) + 1);
+  });
+
   test('hamburger menu opens, navigates, and closes', async ({ page }) => {
     await page.goto('/');
     const trigger = page.locator('button[aria-controls="site-menu-panel"]');

--- a/app/e2e/smoke.spec.ts
+++ b/app/e2e/smoke.spec.ts
@@ -39,4 +39,22 @@ test.describe('Smoke', () => {
     await page.goto('/no-such-page');
     await expect(page.getByRole('heading', { level: 1, name: '404' })).toBeVisible();
   });
+
+  test('hamburger menu opens, navigates, and closes', async ({ page }) => {
+    await page.goto('/');
+    const trigger = page.locator('button[aria-controls="site-menu-panel"]');
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    await trigger.click();
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    const panel = page.getByRole('dialog', { name: /site navigation/i });
+    await expect(panel).toBeVisible();
+
+    const aboutLink = panel.getByRole('link', { name: /about/i });
+    await expect(aboutLink).toBeVisible();
+    await aboutLink.click();
+
+    await expect(page).toHaveURL(/\/about$/);
+    await expect(page.getByRole('dialog', { name: /site navigation/i })).toBeHidden();
+  });
 });

--- a/app/src/components/layout/Layout.tsx
+++ b/app/src/components/layout/Layout.tsx
@@ -1,8 +1,8 @@
-import { Outlet } from 'react-router-dom';
 import { BackgroundFX } from './BackgroundFX';
 import { TopNav } from './TopNav';
 import { Footer } from './Footer';
 import { ChatWidget } from '../chat/ChatWidget';
+import { AnimatedOutlet } from '../motion/AnimatedOutlet';
 
 export function Layout() {
   return (
@@ -10,7 +10,7 @@ export function Layout() {
       <BackgroundFX />
       <TopNav />
       <main className="flex-1 relative" style={{ paddingTop: 'var(--topnav-h, 72px)' }}>
-        <Outlet />
+        <AnimatedOutlet />
       </main>
       <Footer />
       <ChatWidget />

--- a/app/src/components/layout/Layout.tsx
+++ b/app/src/components/layout/Layout.tsx
@@ -9,7 +9,7 @@ export function Layout() {
     <div className="min-h-screen flex flex-col">
       <BackgroundFX />
       <TopNav />
-      <main className="flex-1 relative">
+      <main className="flex-1 relative" style={{ paddingTop: 'var(--topnav-h, 72px)' }}>
         <Outlet />
       </main>
       <Footer />

--- a/app/src/components/layout/TopNav.tsx
+++ b/app/src/components/layout/TopNav.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import { AnimatePresence, motion } from 'motion/react';
 
@@ -11,8 +11,10 @@ const LINKS = [
 
 export function TopNav() {
   const [open, setOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const headerRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -37,9 +39,41 @@ export function TopNav() {
     };
   }, [open]);
 
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 24);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  useLayoutEffect(() => {
+    const el = headerRef.current;
+    if (!el) return;
+    const syncHeight = () => {
+      document.documentElement.style.setProperty('--topnav-h', `${el.offsetHeight}px`);
+    };
+    syncHeight();
+    const ro = new ResizeObserver(syncHeight);
+    ro.observe(el);
+    window.addEventListener('resize', syncHeight);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener('resize', syncHeight);
+    };
+  }, []);
+
   return (
     <>
-      <header className="sticky top-0 z-50 bg-surface/90 backdrop-blur-sm border-b-4 border-tertiary shadow-[0_4px_0_0_rgba(126,87,46,0.2)]">
+      <header
+        ref={headerRef}
+        className={[
+          'fixed top-0 left-0 right-0 z-50 border-b-4 border-tertiary',
+          'backdrop-blur-sm transition-[background-color,box-shadow] duration-200',
+          scrolled
+            ? 'bg-surface shadow-[0_6px_0_0_rgba(126,87,46,0.28)]'
+            : 'bg-surface/90 shadow-[0_4px_0_0_rgba(126,87,46,0.18)]',
+        ].join(' ')}
+      >
         <div className="flex justify-between items-center w-full px-6 py-4 max-w-[1440px] mx-auto">
           <NavLink to="/" className="text-2xl font-black text-tertiary tracking-tighter uppercase">
             Shiyow

--- a/app/src/components/layout/TopNav.tsx
+++ b/app/src/components/layout/TopNav.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef, useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import { AnimatePresence, motion } from 'motion/react';
 
 const LINKS = [
   { to: '/', label: 'Home', end: true },
@@ -8,34 +10,165 @@ const LINKS = [
 ];
 
 export function TopNav() {
-  return (
-    <header className="sticky top-0 z-50 bg-surface/90 backdrop-blur-sm border-b-4 border-tertiary shadow-[0_4px_0_0_rgba(126,87,46,0.2)]">
-      <div className="flex justify-between items-center w-full px-6 py-4 max-w-[1440px] mx-auto">
-        <NavLink to="/" className="text-2xl font-black text-tertiary tracking-tighter uppercase">
-          Shiyow
-        </NavLink>
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
-        <nav className="flex items-center gap-8">
-          {LINKS.map((link) => (
-            <NavLink
-              key={link.to}
-              to={link.to}
-              end={link.end}
-              className={({ isActive }) =>
-                [
-                  'font-bold uppercase tracking-widest text-sm transition-transform duration-100',
-                  'hover:-translate-y-[2px]',
-                  isActive
-                    ? 'text-primary border-b-4 border-primary pb-1'
-                    : 'text-tertiary hover:text-secondary',
-                ].join(' ')
-              }
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    const firstLink = panelRef.current?.querySelector<HTMLAnchorElement>('a');
+    firstLink?.focus();
+
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = '';
+      previouslyFocused?.focus?.();
+    };
+  }, [open]);
+
+  return (
+    <>
+      <header className="sticky top-0 z-50 bg-surface/90 backdrop-blur-sm border-b-4 border-tertiary shadow-[0_4px_0_0_rgba(126,87,46,0.2)]">
+        <div className="flex justify-between items-center w-full px-6 py-4 max-w-[1440px] mx-auto">
+          <NavLink to="/" className="text-2xl font-black text-tertiary tracking-tighter uppercase">
+            Shiyow
+          </NavLink>
+
+          <button
+            ref={triggerRef}
+            type="button"
+            aria-label={open ? 'Close menu' : 'Open menu'}
+            aria-expanded={open}
+            aria-controls="site-menu-panel"
+            onClick={() => setOpen((v) => !v)}
+            className="flex items-center gap-3 pixel-border bg-tertiary-container px-4 py-2 font-black uppercase tracking-widest text-sm text-on-tertiary-container hover:-translate-y-0.5 transition-transform"
+          >
+            <HamburgerIcon open={open} />
+            <span className="hidden sm:inline">{open ? 'Close' : 'Menu'}</span>
+          </button>
+        </div>
+      </header>
+
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div
+              key="backdrop"
+              aria-hidden
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              onClick={() => setOpen(false)}
+              className="fixed inset-0 z-[60] bg-on-surface/40 backdrop-blur-[2px]"
+            />
+
+            <motion.div
+              key="panel"
+              ref={panelRef}
+              id="site-menu-panel"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Site navigation"
+              initial={{ x: '100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '100%' }}
+              transition={{ type: 'tween', duration: 0.35, ease: [0.2, 0.8, 0.2, 1] }}
+              className="fixed top-0 right-0 bottom-0 z-[61] w-[min(22rem,92vw)] bg-surface-container-high border-l-4 border-tertiary shadow-[-4px_0_0_0_rgba(126,87,46,0.25)] flex flex-col"
             >
-              {link.label}
-            </NavLink>
-          ))}
-        </nav>
-      </div>
-    </header>
+              <div className="flex justify-between items-center px-6 py-4 border-b-4 border-tertiary bg-tertiary-container">
+                <span className="font-black uppercase tracking-widest text-xs text-on-tertiary-container">
+                  Menu
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  aria-label="Close menu"
+                  className="font-black uppercase tracking-widest text-xs text-tertiary hover:text-primary"
+                >
+                  Close
+                </button>
+              </div>
+
+              <nav className="flex-1 overflow-auto px-6 py-8">
+                <ul className="space-y-2">
+                  {LINKS.map((link, idx) => (
+                    <motion.li
+                      key={link.to}
+                      initial={{ opacity: 0, x: 24 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      exit={{ opacity: 0, x: 24 }}
+                      transition={{
+                        delay: 0.08 + idx * 0.06,
+                        duration: 0.3,
+                        ease: [0.2, 0.8, 0.2, 1],
+                      }}
+                    >
+                      <NavLink
+                        to={link.to}
+                        end={link.end}
+                        onClick={() => setOpen(false)}
+                        className={({ isActive }) =>
+                          [
+                            'flex items-center gap-3 w-full px-4 py-3 pixel-border-thin bg-surface-container-lowest',
+                            'font-black uppercase tracking-widest text-lg transition-transform',
+                            'hover:-translate-y-0.5 hover:bg-primary hover:text-on-primary',
+                            isActive
+                              ? 'text-primary border-primary shadow-[4px_4px_0_0_var(--color-primary)]'
+                              : 'text-tertiary',
+                          ].join(' ')
+                        }
+                      >
+                        <span className="text-primary font-pixel text-xs">{`0${idx + 1}`}</span>
+                        <span>{link.label}</span>
+                      </NavLink>
+                    </motion.li>
+                  ))}
+                </ul>
+              </nav>
+
+              <footer className="px-6 py-4 border-t-4 border-tertiary bg-surface-container text-[10px] font-black uppercase tracking-widest text-on-surface-variant">
+                shiyow.dev · 16-Bit Atélier
+              </footer>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}
+
+function HamburgerIcon({ open }: { open: boolean }) {
+  return (
+    <span aria-hidden className="relative block w-5 h-5">
+      <motion.span
+        className="absolute left-0 right-0 h-[3px] bg-on-tertiary-container"
+        style={{ top: '20%' }}
+        animate={open ? { rotate: 45, top: '50%', translateY: '-50%' } : { rotate: 0, top: '20%' }}
+        transition={{ duration: 0.25 }}
+      />
+      <motion.span
+        className="absolute left-0 right-0 h-[3px] bg-on-tertiary-container top-1/2 -translate-y-1/2"
+        animate={open ? { opacity: 0 } : { opacity: 1 }}
+        transition={{ duration: 0.15 }}
+      />
+      <motion.span
+        className="absolute left-0 right-0 h-[3px] bg-on-tertiary-container"
+        style={{ top: '80%' }}
+        animate={open ? { rotate: -45, top: '50%', translateY: '-50%' } : { rotate: 0, top: '80%' }}
+        transition={{ duration: 0.25 }}
+      />
+    </span>
   );
 }

--- a/app/src/components/layout/TopNav.tsx
+++ b/app/src/components/layout/TopNav.tsx
@@ -15,7 +15,7 @@ export function TopNav() {
           Shiyow
         </NavLink>
 
-        <nav className="hidden md:flex items-center gap-8">
+        <nav className="flex items-center gap-8">
           {LINKS.map((link) => (
             <NavLink
               key={link.to}
@@ -35,30 +35,6 @@ export function TopNav() {
             </NavLink>
           ))}
         </nav>
-
-        <div className="flex items-center gap-4">
-          <button
-            type="button"
-            className="pixel-button hidden sm:inline-flex"
-            aria-label="Download resume"
-          >
-            Resume
-          </button>
-          <div className="flex gap-2 text-tertiary">
-            <span
-              className="material-symbols-outlined cursor-pointer hover:text-primary"
-              aria-hidden
-            >
-              settings
-            </span>
-            <span
-              className="material-symbols-outlined cursor-pointer hover:text-primary"
-              aria-hidden
-            >
-              account_circle
-            </span>
-          </div>
-        </div>
       </div>
     </header>
   );

--- a/app/src/components/motion/AnimatedOutlet.tsx
+++ b/app/src/components/motion/AnimatedOutlet.tsx
@@ -1,0 +1,27 @@
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
+import { useLocation, useOutlet } from 'react-router-dom';
+import { routeTransition } from '../../lib/motion';
+
+export function AnimatedOutlet() {
+  const location = useLocation();
+  const element = useOutlet();
+  const reduce = useReducedMotion();
+
+  if (reduce) {
+    return <>{element}</>;
+  }
+
+  return (
+    <AnimatePresence mode="wait" initial={false}>
+      <motion.div
+        key={location.pathname}
+        variants={routeTransition}
+        initial="initial"
+        animate="enter"
+        exit="exit"
+      >
+        {element}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/app/src/components/motion/Reveal.tsx
+++ b/app/src/components/motion/Reveal.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react';
+import { motion, useReducedMotion, type Variants } from 'motion/react';
+import { fadeUp } from '../../lib/motion';
+
+interface RevealProps {
+  children: ReactNode;
+  as?: 'div' | 'section' | 'article' | 'li' | 'header' | 'aside';
+  variants?: Variants;
+  delay?: number;
+  amount?: number;
+  once?: boolean;
+  className?: string;
+}
+
+export function Reveal({
+  children,
+  as = 'div',
+  variants = fadeUp,
+  delay = 0,
+  amount = 0.25,
+  once = true,
+  className,
+}: RevealProps) {
+  const reduce = useReducedMotion();
+  const MotionTag = motion[as];
+
+  if (reduce) {
+    const Tag = as;
+    return <Tag className={className}>{children}</Tag>;
+  }
+
+  return (
+    <MotionTag
+      className={className}
+      variants={variants}
+      initial="hidden"
+      whileInView="show"
+      viewport={{ once, amount }}
+      transition={{ delay }}
+    >
+      {children}
+    </MotionTag>
+  );
+}

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -227,6 +227,39 @@ img.pixelated {
 }
 
 /* ==============================================================
+   Link underline wipe (left → right on hover)
+   ============================================================== */
+
+.link-wipe {
+  position: relative;
+  display: inline-block;
+}
+
+.link-wipe::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -3px;
+  height: 3px;
+  background-color: currentColor;
+  transform: scaleX(0);
+  transform-origin: left center;
+  transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.link-wipe:hover::after,
+.link-wipe:focus-visible::after {
+  transform: scaleX(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .link-wipe::after {
+    transition: none;
+  }
+}
+
+/* ==============================================================
    Material Symbols
    ============================================================== */
 

--- a/app/src/lib/motion.ts
+++ b/app/src/lib/motion.ts
@@ -1,0 +1,45 @@
+import type { Transition, Variants } from 'motion/react';
+
+export const easeOutExpo: Transition['ease'] = [0.22, 1, 0.36, 1];
+
+export const fadeUp: Variants = {
+  hidden: { opacity: 0, y: 16 },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: easeOutExpo },
+  },
+};
+
+export const fadeIn: Variants = {
+  hidden: { opacity: 0 },
+  show: { opacity: 1, transition: { duration: 0.4, ease: easeOutExpo } },
+};
+
+export const slideDown: Variants = {
+  hidden: { opacity: 0, y: -16 },
+  show: { opacity: 1, y: 0, transition: { duration: 0.5, ease: easeOutExpo } },
+};
+
+export function staggerContainer(staggerChildren = 0.06, delayChildren = 0): Variants {
+  return {
+    hidden: {},
+    show: {
+      transition: { staggerChildren, delayChildren },
+    },
+  };
+}
+
+export const routeTransition: Variants = {
+  initial: { opacity: 0, y: 12 },
+  enter: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.35, ease: easeOutExpo },
+  },
+  exit: {
+    opacity: 0,
+    y: -8,
+    transition: { duration: 0.2, ease: 'easeIn' },
+  },
+};

--- a/app/src/routes/About.tsx
+++ b/app/src/routes/About.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { PROFILE } from '../lib/profile';
+import { Reveal } from '../components/motion/Reveal';
 
 const CHARACTER_SRC = '/characters/shiyow.png';
 
@@ -27,7 +28,7 @@ export function About() {
 
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-12">
         <div className="lg:col-span-5 space-y-8">
-          <section className="relative bg-surface-container-high pixel-border p-1">
+          <Reveal as="section" className="relative bg-surface-container-high pixel-border p-1">
             <div className="bg-surface-container-lowest border-2 border-outline-variant p-6">
               <div className="relative flex flex-col items-center mb-8">
                 <div className="w-48 h-48 bg-surface-container-high border-4 border-tertiary flex items-center justify-center overflow-hidden">
@@ -87,9 +88,13 @@ export function About() {
                 })}
               </div>
             </div>
-          </section>
+          </Reveal>
 
-          <section className="relative bg-tertiary-container pixel-border p-6">
+          <Reveal
+            as="section"
+            className="relative bg-tertiary-container pixel-border p-6"
+            delay={0.08}
+          >
             <div className="absolute -top-3 left-6 bg-tertiary text-on-tertiary px-3 py-1 text-[10px] font-black uppercase tracking-widest">
               Biography
             </div>
@@ -98,11 +103,15 @@ export function About() {
                 &ldquo;{PROFILE.bioQuote}&rdquo;
               </p>
             </div>
-          </section>
+          </Reveal>
         </div>
 
         <div className="lg:col-span-7">
-          <section className="bg-surface-container pixel-border p-6 md:p-8">
+          <Reveal
+            as="section"
+            className="bg-surface-container pixel-border p-6 md:p-8"
+            delay={0.04}
+          >
             <header className="mb-8 flex items-start justify-between">
               <div>
                 <h2 className="text-2xl md:text-3xl font-black uppercase tracking-tighter text-on-surface">
@@ -183,15 +192,19 @@ export function About() {
                 ))}
               </ul>
             </footer>
-          </section>
+          </Reveal>
 
-          <section className="mt-8 bg-surface-container-lowest pixel-border p-6 md:p-8">
+          <Reveal
+            as="section"
+            className="mt-8 bg-surface-container-lowest pixel-border p-6 md:p-8"
+            delay={0.12}
+          >
             <h3 className="text-xl font-black uppercase tracking-tighter text-on-surface mb-6">
               Recent Milestones
             </h3>
             <ol className="space-y-4">
-              {PROFILE.history.map((event) => (
-                <li key={event.year} className="flex gap-5">
+              {PROFILE.history.map((event, idx) => (
+                <Reveal as="li" key={event.year} className="flex gap-5" delay={0.04 * idx}>
                   <span className="bg-tertiary text-on-tertiary px-3 py-1 h-fit font-black text-xs tracking-widest uppercase">
                     {event.year}
                   </span>
@@ -199,13 +212,13 @@ export function About() {
                     <h4 className="font-black uppercase tracking-tight">{event.title}</h4>
                     <p className="text-sm text-on-surface-variant">{event.detail}</p>
                   </div>
-                </li>
+                </Reveal>
               ))}
             </ol>
             <Link to="/gallery" className="pixel-button pixel-button--tertiary mt-6 inline-flex">
               See full quest log
             </Link>
-          </section>
+          </Reveal>
         </div>
       </div>
     </section>

--- a/app/src/routes/Changelog.tsx
+++ b/app/src/routes/Changelog.tsx
@@ -1,4 +1,5 @@
 import { RELEASES, type ChangeKind, type ReleaseStatus } from '../lib/changelog';
+import { Reveal } from '../components/motion/Reveal';
 
 const KIND_COLOR: Record<ChangeKind, string> = {
   feature: 'text-secondary',
@@ -65,8 +66,13 @@ export function Changelog() {
                 className="absolute left-[11px] top-2 bottom-2 w-1 bg-outline-variant opacity-30"
                 aria-hidden
               />
-              {RELEASES.map((release) => (
-                <li key={release.version} className="relative pl-10 pb-10 last:pb-0">
+              {RELEASES.map((release, idx) => (
+                <Reveal
+                  key={release.version}
+                  as="li"
+                  delay={Math.min(idx * 0.08, 0.24)}
+                  className="relative pl-10 pb-10 last:pb-0"
+                >
                   <span
                     aria-hidden
                     className={[
@@ -116,7 +122,7 @@ export function Changelog() {
                       </ul>
                     )}
                   </div>
-                </li>
+                </Reveal>
               ))}
             </ol>
           </div>

--- a/app/src/routes/Gallery.tsx
+++ b/app/src/routes/Gallery.tsx
@@ -8,6 +8,7 @@ import {
   type Work,
   type WorkCategory,
 } from '../lib/works';
+import { Reveal } from '../components/motion/Reveal';
 
 const STATUS_LABEL: Record<Work['status'], string> = {
   new: 'New',
@@ -98,9 +99,11 @@ export function Gallery() {
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
-              {works.map((work) => (
-                <article
+              {works.map((work, idx) => (
+                <Reveal
                   key={work.id}
+                  as="article"
+                  delay={Math.min(idx * 0.05, 0.3)}
                   className="bg-surface-container-highest pixel-border flex flex-col hover:-translate-y-1 transition-transform"
                 >
                   <Link to={`/works/${work.id}`} className="contents">
@@ -145,7 +148,7 @@ export function Gallery() {
                       </ul>
                     </div>
                   </Link>
-                </article>
+                </Reveal>
               ))}
             </div>
           )}

--- a/app/src/routes/Home.tsx
+++ b/app/src/routes/Home.tsx
@@ -11,6 +11,7 @@ import {
   Lock,
 } from 'lucide-react';
 import { WanderingCharacter } from '../components/pixel/WanderingCharacter';
+import { Reveal } from '../components/motion/Reveal';
 const CHARACTER_SRC = '/characters/shiyow.png';
 const ROOM_SRC = '/rooms/simple_room.png';
 
@@ -61,8 +62,8 @@ export function Home() {
     <section className="max-w-[1440px] mx-auto px-6 py-12 md:py-20 relative">
       {/* Hero */}
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-12 items-start">
-        {/* Companion Sidebar */}
-        <aside className="lg:col-span-3 order-2 lg:order-1">
+        {/* Profile Sidebar */}
+        <Reveal as="aside" className="lg:col-span-3 order-2 lg:order-1">
           <div className="pixel-border bg-tertiary-container p-6 space-y-4">
             <div className="flex items-center gap-3 mb-2">
               <div className="w-14 h-14 bg-surface pixel-border-thin flex items-center justify-center overflow-hidden">
@@ -99,7 +100,7 @@ export function Home() {
               &ldquo;The pixels are warm today. Perfect for crafting new worlds.&rdquo;
             </div>
           </div>
-        </aside>
+        </Reveal>
 
         {/* Center Stage */}
         <div className="lg:col-span-6 order-1 lg:order-2 flex flex-col items-center">
@@ -122,7 +123,7 @@ export function Home() {
         </div>
 
         {/* Right: Quest + Inventory */}
-        <aside className="lg:col-span-3 order-3">
+        <Reveal as="aside" className="lg:col-span-3 order-3" delay={0.1}>
           <div className="pixel-border bg-surface-container-highest p-6 space-y-6">
             <div>
               <h3 className="text-xs font-black uppercase tracking-widest text-tertiary border-b-2 border-tertiary pb-1 mb-3">
@@ -166,77 +167,82 @@ export function Home() {
               View Stats
             </Link>
           </div>
-        </aside>
+        </Reveal>
       </div>
 
       {/* Featured — Recent Loot bento */}
       <section className="mt-24 md:mt-32">
-        <header className="flex items-end justify-between mb-8 md:mb-12">
+        <Reveal as="header" className="flex items-end justify-between mb-8 md:mb-12">
           <h2 className="text-3xl md:text-4xl font-black uppercase tracking-tighter text-on-surface">
             Recent Loot
           </h2>
           <div className="hidden md:block h-1 flex-grow mx-8 bg-surface-container-highest" />
           <Link
             to="/gallery"
-            className="text-primary font-black uppercase text-xs tracking-widest hover:underline"
+            className="link-wipe text-primary font-black uppercase text-xs tracking-widest"
           >
             View All Quests
           </Link>
-        </header>
+        </Reveal>
 
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
           {/* Large */}
-          <Link
-            to={`/works/${FEATURED[0].id}`}
-            className="md:col-span-2 md:row-span-2 bg-surface-container-lowest pixel-border flex flex-col hover:-translate-y-1 transition-transform"
-          >
-            <div className="h-60 md:h-64 bg-gradient-to-br from-primary-container to-secondary-container border-b-4 border-tertiary" />
-            <div className="p-6 flex-grow flex flex-col">
-              <span className="inline-block px-2 py-1 bg-secondary-container text-on-secondary-container text-[10px] font-black uppercase tracking-widest mb-4 w-fit">
-                {FEATURED[0].tag}
-              </span>
-              <h3 className="text-2xl font-black uppercase mb-2 text-on-surface">
-                {FEATURED[0].title}
-              </h3>
-              <p className="text-sm text-on-surface-variant mb-6">{FEATURED[0].desc}</p>
-              <div className="mt-auto flex justify-between items-center">
-                <span className="text-xs font-black uppercase text-tertiary tracking-widest">
-                  {FEATURED[0].xp}
+          <Reveal className="md:col-span-2 md:row-span-2" delay={0}>
+            <Link
+              to={`/works/${FEATURED[0].id}`}
+              className="h-full bg-surface-container-lowest pixel-border flex flex-col hover:-translate-y-1 transition-transform"
+            >
+              <div className="h-60 md:h-64 bg-gradient-to-br from-primary-container to-secondary-container border-b-4 border-tertiary" />
+              <div className="p-6 flex-grow flex flex-col">
+                <span className="inline-block px-2 py-1 bg-secondary-container text-on-secondary-container text-[10px] font-black uppercase tracking-widest mb-4 w-fit">
+                  {FEATURED[0].tag}
                 </span>
-                <ArrowRight size={20} className="text-primary" />
+                <h3 className="text-2xl font-black uppercase mb-2 text-on-surface">
+                  {FEATURED[0].title}
+                </h3>
+                <p className="text-sm text-on-surface-variant mb-6">{FEATURED[0].desc}</p>
+                <div className="mt-auto flex justify-between items-center">
+                  <span className="text-xs font-black uppercase text-tertiary tracking-widest">
+                    {FEATURED[0].xp}
+                  </span>
+                  <ArrowRight size={20} className="text-primary" />
+                </div>
               </div>
-            </div>
-          </Link>
+            </Link>
+          </Reveal>
 
           {/* Small 1 & 2 */}
-          {FEATURED.slice(1).map((f) => (
-            <Link
-              key={f.id}
-              to={`/works/${f.id}`}
-              className="bg-surface-container-lowest pixel-border p-4 hover:-translate-y-1 transition-transform"
-            >
-              <div className="h-32 bg-gradient-to-br from-tertiary-container to-primary-container mb-4 border-2 border-outline-variant" />
-              <h4 className="font-black uppercase text-sm mb-1 text-on-surface">{f.title}</h4>
-              <p className="text-xs text-on-surface-variant uppercase font-black tracking-widest">
-                {f.tag}
-              </p>
-            </Link>
+          {FEATURED.slice(1).map((f, i) => (
+            <Reveal key={f.id} delay={0.08 * (i + 1)}>
+              <Link
+                to={`/works/${f.id}`}
+                className="block h-full bg-surface-container-lowest pixel-border p-4 hover:-translate-y-1 transition-transform"
+              >
+                <div className="h-32 bg-gradient-to-br from-tertiary-container to-primary-container mb-4 border-2 border-outline-variant" />
+                <h4 className="font-black uppercase text-sm mb-1 text-on-surface">{f.title}</h4>
+                <p className="text-xs text-on-surface-variant uppercase font-black tracking-widest">
+                  {f.tag}
+                </p>
+              </Link>
+            </Reveal>
           ))}
 
           {/* CTA */}
-          <div className="md:col-span-2 bg-primary-container pixel-border-primary p-6 flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
-            <div>
-              <h3 className="text-xl font-black uppercase text-on-primary-container">
-                Ready for a new quest?
-              </h3>
-              <p className="text-sm text-on-primary-container opacity-80 mt-1">
-                作品のご相談、コラボ、コミッションを受付中です。
-              </p>
+          <Reveal className="md:col-span-2" delay={0.24}>
+            <div className="h-full bg-primary-container pixel-border-primary p-6 flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+              <div>
+                <h3 className="text-xl font-black uppercase text-on-primary-container">
+                  Ready for a new quest?
+                </h3>
+                <p className="text-sm text-on-primary-container opacity-80 mt-1">
+                  作品のご相談、コラボ、コミッションを受付中です。
+                </p>
+              </div>
+              <Link to="/gallery" className="pixel-button whitespace-nowrap">
+                Start Quest
+              </Link>
             </div>
-            <Link to="/gallery" className="pixel-button whitespace-nowrap">
-              Start Quest
-            </Link>
-          </div>
+          </Reveal>
         </div>
       </section>
     </section>

--- a/app/src/test/setup.ts
+++ b/app/src/test/setup.ts
@@ -1,6 +1,30 @@
 import '@testing-library/jest-dom/vitest';
-import { afterEach } from 'vitest';
+import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
+
+if (typeof window !== 'undefined' && !('IntersectionObserver' in window)) {
+  class MockIntersectionObserver implements IntersectionObserver {
+    readonly root: Element | Document | null = null;
+    readonly rootMargin: string = '';
+    readonly thresholds: ReadonlyArray<number> = [];
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+    takeRecords = vi.fn(() => []);
+  }
+  (window as unknown as { IntersectionObserver: typeof IntersectionObserver }).IntersectionObserver =
+    MockIntersectionObserver as unknown as typeof IntersectionObserver;
+}
+
+if (typeof window !== 'undefined' && !('ResizeObserver' in window)) {
+  class MockResizeObserver {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+  }
+  (window as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+    MockResizeObserver as unknown as typeof ResizeObserver;
+}
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
Closes #28

**依存:** このブランチは #31 (fix/topnav-fixed-header) の上に積んでいます。順番は #29 → #30 → #31 → 本 PR を想定。現状は全て main から分岐しているため単独でマージ可能です。

参考: https://yharuto.dev/

## 追加した共通ユーティリティ
| ファイル | 役割 |
|---|---|
| `src/lib/motion.ts` | `fadeUp` / `fadeIn` / `slideDown` / `routeTransition` Variants + `easeOutExpo` カーブ |
| `src/components/motion/Reveal.tsx` | `whileInView` の fadeUp を一括適用するラッパー。`useReducedMotion` が有効なら静的 fallback |
| `src/components/motion/AnimatedOutlet.tsx` | `useOutlet` + `AnimatePresence` でページ遷移を fade+slide アニメ化 |

## 各ページへの適用
- **Home**: Profile / Quest サイドバーと Featured bento カードを順に reveal (delay 指定で stagger 感)、"View All Quests" リンクを link-wipe に
- **Gallery**: 作品カード grid が上から順に reveal (idx × 50ms)
- **Changelog**: タイムラインの各リリースを 80ms ずつ stagger
- **About**: Character Sheet / Biography / Ability Board / Milestones を個別に reveal、マイルストーンは 1 項目ずつさらに reveal
- **Layout**: `Outlet` を `AnimatedOutlet` に置換、ページ切替時に fade+slide

## CSS
- `.link-wipe` ユーティリティ: hover / focus で下線が左→右ワイプ、`prefers-reduced-motion` 対応

## テスト環境整備
- `src/test/setup.ts` に `IntersectionObserver` + `ResizeObserver` のモック追加 (jsdom 未実装のため `whileInView` が Vitest で使えない問題を修正)

## 検証
- `npm run build` / `lint` / `test` (Vitest 3/3) / Playwright (8/8) すべて緑
- dev server 上でページ遷移・スクロールリビール・リンクホバーのアニメ動作確認済

## 今後の拡張余地 (別 Issue)
- Hero タイトルの文字単位 stagger
- scanline 強度のスクロール連動
- 作品詳細 (#20) でカルーセルを入れる際の transition 統一