### PR TITLE
fix(test): IntersectionObserver スタブの型実装エラーで main の CI 3 本落ちを修正

### DIFF
--- a/app/src/test/setup.ts
+++ b/app/src/test/setup.ts
@@ -2,28 +2,32 @@ import '@testing-library/jest-dom/vitest';
 import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 
+/**
+ * jsdom (Vitest 環境) では IntersectionObserver / ResizeObserver が未実装。
+ * motion/react の `whileInView` や TopNav の ResizeObserver が参照する
+ * のでダミーを生やしておく。厳密な DOM 型に準拠させる必要はないので
+ * `unknown as typeof ...` でキャストして最低限のメソッドだけ提供する。
+ */
+
 if (typeof window !== 'undefined' && !('IntersectionObserver' in window)) {
-  class MockIntersectionObserver implements IntersectionObserver {
-    readonly root: Element | Document | null = null;
-    readonly rootMargin: string = '';
-    readonly thresholds: ReadonlyArray<number> = [];
+  const stub = class {
     observe = vi.fn();
     unobserve = vi.fn();
     disconnect = vi.fn();
     takeRecords = vi.fn(() => []);
-  }
-  (window as unknown as { IntersectionObserver: typeof IntersectionObserver }).IntersectionObserver =
-    MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  };
+  (window as unknown as { IntersectionObserver: unknown }).IntersectionObserver =
+    stub as unknown as typeof IntersectionObserver;
 }
 
 if (typeof window !== 'undefined' && !('ResizeObserver' in window)) {
-  class MockResizeObserver {
+  const stub = class {
     observe = vi.fn();
     unobserve = vi.fn();
     disconnect = vi.fn();
-  }
-  (window as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
-    MockResizeObserver as unknown as typeof ResizeObserver;
+  };
+  (window as unknown as { ResizeObserver: unknown }).ResizeObserver =
+    stub as unknown as typeof ResizeObserver;
 }
 
 afterEach(() => {


### PR DESCRIPTION
## 原因
PR #32 マージ後、main で 3 つの CI が失敗していました。

- **Lint (tsc)**: `Class 'MockIntersectionObserver' incorrectly implements interface 'IntersectionObserver'. Property 'scrollMargin' is missing.`
- **Playwright Smoke**: 上と同じく npm run build → tsc が失敗
- **Format Check**: `src/test/setup.ts` が Prettier 未適用

PR #32 のブランチ時点では build が通っていたが、main 取り込み後に TS の DOM lib 定義が lib.dom.d.ts バージョン差で `scrollMargin` を要求するようになり、型実装エラーで落ちた。

## 修正
- `src/test/setup.ts` のスタブクラスから `implements IntersectionObserver` を外す
- 匿名クラスを `unknown as typeof IntersectionObserver` でキャストする最小限の形に変更 (ResizeObserver も同様)
- これで DOM lib に新プロパティが増えても影響しない
- 同時に prettier --check を通るように整形

## 検証
- `tsc --noEmit` / `prettier --check` / `eslint` すべて通過
- Vitest 3/3 pass
- Playwright 8/8 pass