### PR TITLE
feat(about): techStack の各項目にブランドアイコンを表示

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,7 +12,8 @@
         "motion": "^12.23.24",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.14.2"
+        "react-router-dom": "^7.14.2",
+        "simple-icons": "^16.17.0"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260421.1",
@@ -4619,6 +4620,24 @@
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
+    },
+    "node_modules/simple-icons": {
+      "version": "16.17.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.17.0.tgz",
+      "integrity": "sha512-bRrGtzM6NLgxeMWmRcfDdrRksECk101lRrCn6jjj6qzUB6lQ+E5smnr52rqS1kLPmbLpS/g6iF463j50M4BT7A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/simple-icons"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/simple-icons"
+        }
+      ],
+      "engines": {
+        "node": ">=0.12.18"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/app/package.json
+++ b/app/package.json
@@ -25,7 +25,8 @@
     "motion": "^12.23.24",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.14.2"
+    "react-router-dom": "^7.14.2",
+    "simple-icons": "^16.17.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260421.1",

--- a/app/src/components/pixel/TechIcon.tsx
+++ b/app/src/components/pixel/TechIcon.tsx
@@ -1,0 +1,129 @@
+import {
+  siAnthropic,
+  siCloudflare,
+  siFigma,
+  siFramer,
+  siGit,
+  siGithub,
+  siGo,
+  siGodotengine,
+  siGooglecloud,
+  siGooglegemini,
+  siJavascript,
+  siLangchain,
+  siNodedotjs,
+  siPython,
+  siReact,
+  siReactrouter,
+  siTailwindcss,
+  siTypescript,
+  siUnity,
+  siVercel,
+  siVite,
+} from 'simple-icons';
+
+interface SIcon {
+  path: string;
+}
+
+interface IconSpec {
+  si?: SIcon;
+  ms?: string;
+}
+
+/**
+ * 技術名 → 表示アイコンのマップ。si は simple-icons の SVG path、
+ * ms は Material Symbols の記号名 (brand logo が無いものの fallback)。
+ */
+const TECH_ICONS: Record<string, IconSpec> = {
+  // Languages
+  TypeScript: { si: siTypescript },
+  JavaScript: { si: siJavascript },
+  Python: { si: siPython },
+  Go: { si: siGo },
+  SQL: { ms: 'database' },
+
+  // Frameworks & Runtime
+  'React 19': { si: siReact },
+  'Vite 6': { si: siVite },
+  'Tailwind CSS v4': { si: siTailwindcss },
+  Motion: { si: siFramer },
+  'React Router': { si: siReactrouter },
+  'Node.js': { si: siNodedotjs },
+
+  // Design & Pixel Art
+  Figma: { si: siFigma },
+  FigJam: { si: siFigma },
+  Aseprite: { ms: 'brush' },
+  Photoshop: { ms: 'draw' },
+
+  // Cloud & Infra
+  'Cloudflare Pages': { si: siCloudflare },
+  Workers: { si: siCloudflare },
+  D1: { ms: 'database' },
+  R2: { ms: 'cloud' },
+  KV: { ms: 'key_vertical' },
+  GCP: { si: siGooglecloud },
+  Vercel: { si: siVercel },
+
+  // AI & Agents
+  'Gemini 2.0 Flash': { si: siGooglegemini },
+  Claude: { si: siAnthropic },
+  LangChain: { si: siLangchain },
+  'Vectorize (Workers AI)': { ms: 'psychology' },
+
+  // Game Dev
+  Unity: { si: siUnity },
+  Godot: { si: siGodotengine },
+
+  // Tools
+  'VS Code': { ms: 'code' },
+  Git: { si: siGit },
+  'gh CLI': { si: siGithub },
+  tmux: { ms: 'terminal' },
+  Wrangler: { si: siCloudflare },
+};
+
+interface TechIconProps {
+  name: string;
+  size?: number;
+  className?: string;
+}
+
+export function TechIcon({ name, size = 14, className }: TechIconProps) {
+  const spec = TECH_ICONS[name];
+  if (spec?.si) {
+    return (
+      <svg
+        viewBox="0 0 24 24"
+        width={size}
+        height={size}
+        fill="currentColor"
+        aria-hidden
+        className={className}
+      >
+        <path d={spec.si.path} />
+      </svg>
+    );
+  }
+  if (spec?.ms) {
+    return (
+      <span
+        className={['material-symbols-outlined', className].filter(Boolean).join(' ')}
+        style={{ fontSize: size }}
+        aria-hidden
+      >
+        {spec.ms}
+      </span>
+    );
+  }
+  return (
+    <span
+      className={['material-symbols-outlined', className].filter(Boolean).join(' ')}
+      style={{ fontSize: size }}
+      aria-hidden
+    >
+      circle
+    </span>
+  );
+}

--- a/app/src/routes/About.tsx
+++ b/app/src/routes/About.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { PROFILE } from '../lib/profile';
 import { Reveal } from '../components/motion/Reveal';
+import { TechIcon } from '../components/pixel/TechIcon';
 
 const CHARACTER_SRC = '/characters/shiyow.png';
 
@@ -160,9 +161,10 @@ export function About() {
                     {group.items.map((item) => (
                       <li
                         key={item}
-                        className="text-xs font-black uppercase tracking-widest px-2 py-1 bg-tertiary-container text-on-tertiary-container border-2 border-tertiary/40"
+                        className="inline-flex items-center gap-1.5 text-xs font-black uppercase tracking-widest px-2 py-1 bg-tertiary-container text-on-tertiary-container border-2 border-tertiary/40"
                       >
-                        {item}
+                        <TechIcon name={item} size={14} />
+                        <span>{item}</span>
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## 概要
About の Skills & Tech Stack に並ぶ各項目 (TypeScript / React / Figma / Cloudflare 等) に、ブランドロゴ or Material Symbols アイコンを付けました。ラベルだけでは視認性が低かったため。

## 実装
- **simple-icons** を導入 (ブランドロゴの SVG path データパッケージ、~4MB だが tree-shake されて実際バンドル増分は +12KB gzip)
- 新規 `src/components/pixel/TechIcon.tsx`:
  - `{ name: string }` を受け取り、内部マップから `{ si?: { path }, ms?: string }` を解決
  - `si` があれば `simple-icons` の path を inline SVG で描画
  - `ms` なら Material Symbols
  - どちらも無ければ circle プレースホルダ
  - 全アイコンは `currentColor` で描画するため tertiary-container 色と自然に馴染む (ブランドカラーで浮かない)

## 対応項目 (マップ済み)
| カテゴリ | simple-icons | Material Symbols fallback |
|---|---|---|
| Languages | TypeScript / JavaScript / Python / Go | SQL (database) |
| Frameworks | React / Vite / Tailwind / Motion / React Router / Node.js | — |
| Design | Figma / FigJam | Aseprite (brush) / Photoshop (draw) |
| Cloud | Cloudflare Pages / Workers / Wrangler / GCP / Vercel | D1 / R2 / KV |
| AI | Gemini / Claude (Anthropic) / LangChain | Vectorize (psychology) |
| Game Dev | Unity / Godot | — |
| Tools | Git / gh CLI | VS Code (code) / tmux (terminal) |

## テスト
- build / lint / prettier / Vitest 3/3 / Playwright 8/8 すべて緑
- JS gzip: 131KB → 143KB (+12KB, tree-shake 後のみ)