### PR TITLE
test: ルート・コンポーネント・lib のユニットテストを追加 (カバレッジ 68%→89%)

### DIFF
--- a/app/src/components/layout/Footer.test.tsx
+++ b/app/src/components/layout/Footer.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Footer } from './Footer';
+
+describe('Footer', () => {
+  it('renders the handcrafted copyright line', () => {
+    render(<Footer />);
+    expect(screen.getByText(/handcrafted with pixels/i)).toBeInTheDocument();
+  });
+
+  it('renders the GitHub, Itch.io and Contact links', () => {
+    render(<Footer />);
+    expect(screen.getByRole('link', { name: /github/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /itch\.io/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /contact/i })).toBeInTheDocument();
+  });
+
+  it('points the GitHub link at github.com', () => {
+    render(<Footer />);
+    const href = screen.getByRole('link', { name: /github/i }).getAttribute('href');
+    expect(href).toContain('github.com');
+  });
+
+  it('shows the server-online status indicator', () => {
+    render(<Footer />);
+    expect(screen.getByText(/server online/i)).toBeInTheDocument();
+  });
+});

--- a/app/src/components/layout/TopNav.test.tsx
+++ b/app/src/components/layout/TopNav.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { TopNav } from './TopNav';
+
+function renderNav() {
+  return render(
+    <MemoryRouter>
+      <TopNav />
+    </MemoryRouter>,
+  );
+}
+
+describe('TopNav', () => {
+  it('renders the brand and a collapsed menu trigger', () => {
+    renderNav();
+    expect(screen.getByRole('link', { name: /shiyow/i })).toBeInTheDocument();
+    const trigger = screen.getByRole('button', { name: /open menu/i });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens the slide-in panel with the navigation links', async () => {
+    const user = userEvent.setup();
+    renderNav();
+
+    await user.click(screen.getByRole('button', { name: /open menu/i }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /about/i })).toHaveAttribute('href', '/about');
+    expect(screen.getByRole('link', { name: /gallery/i })).toHaveAttribute('href', '/gallery');
+    expect(screen.getByRole('link', { name: /changelog/i })).toHaveAttribute('href', '/changelog');
+  });
+
+  it('closes the panel when Escape is pressed', async () => {
+    const user = userEvent.setup();
+    renderNav();
+
+    await user.click(screen.getByRole('button', { name: /open menu/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /open menu/i })).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      ),
+    );
+  });
+});

--- a/app/src/lib/activity.test.ts
+++ b/app/src/lib/activity.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ACTIVITIES,
+  CATEGORY_COLOR,
+  CATEGORY_ICON,
+  CATEGORY_LABEL,
+  formatDate,
+  groupByYear,
+} from './activity';
+
+describe('ACTIVITIES', () => {
+  it('is sorted by date descending (newest first)', () => {
+    for (let i = 0; i < ACTIVITIES.length - 1; i += 1) {
+      expect(ACTIVITIES[i].date >= ACTIVITIES[i + 1].date).toBe(true);
+    }
+  });
+
+  it('uses unique ids', () => {
+    const ids = ACTIVITIES.map((activity) => activity.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('formatDate', () => {
+  it('renders an ISO date as dotted segments', () => {
+    expect(formatDate('2026-04-22')).toBe('2026.04.22');
+  });
+});
+
+describe('groupByYear', () => {
+  it('orders the year groups descending', () => {
+    const years = groupByYear().map((group) => group.year);
+    expect(years).toEqual([...years].sort((a, b) => b - a));
+  });
+
+  it('keeps every activity exactly once', () => {
+    const total = groupByYear().reduce((sum, group) => sum + group.entries.length, 0);
+    expect(total).toBe(ACTIVITIES.length);
+  });
+
+  it('places each entry in the bucket matching its date year', () => {
+    for (const group of groupByYear()) {
+      for (const entry of group.entries) {
+        expect(Number.parseInt(entry.date.slice(0, 4), 10)).toBe(group.year);
+      }
+    }
+  });
+});
+
+describe('category lookup tables', () => {
+  const categories = ['project', 'release', 'talk', 'award', 'job', 'post'] as const;
+
+  it('provides a label, icon and colour for every category', () => {
+    for (const category of categories) {
+      expect(CATEGORY_LABEL[category]).toBeTruthy();
+      expect(CATEGORY_ICON[category]).toBeTruthy();
+      expect(CATEGORY_COLOR[category]).toBeTruthy();
+    }
+  });
+});

--- a/app/src/lib/chat.test.ts
+++ b/app/src/lib/chat.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { streamChat, type ChatMessage } from './chat';
+
+const MESSAGES: ChatMessage[] = [{ role: 'user', content: 'hi' }];
+
+/** Build a fake streaming Response whose body yields the given NDJSON lines. */
+function streamResponse(lines: string[]): Response {
+  const encoder = new TextEncoder();
+  const chunks = lines.map((line) => encoder.encode(line));
+  let i = 0;
+  const reader = {
+    read: vi.fn(async () => {
+      if (i < chunks.length) return { value: chunks[i++], done: false };
+      return { value: undefined, done: true };
+    }),
+  };
+  return {
+    ok: true,
+    status: 200,
+    body: { getReader: () => reader },
+    json: async () => ({}),
+  } as unknown as Response;
+}
+
+/** Run streamChat to completion, collecting deltas and the terminal outcome. */
+function run(makeFetch: () => Promise<Response>) {
+  vi.stubGlobal('fetch', vi.fn(makeFetch));
+  const deltas: string[] = [];
+  return new Promise<{ deltas: string[]; done: boolean; error?: string }>((resolve) => {
+    streamChat(MESSAGES, 'token', {
+      onDelta: (delta) => deltas.push(delta),
+      onDone: () => resolve({ deltas, done: true }),
+      onError: (error) => resolve({ deltas, done: false, error }),
+    });
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('streamChat', () => {
+  it('returns an AbortController', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => streamResponse(['{"done":true}\n'])),
+    );
+    const controller = streamChat(MESSAGES, undefined, {
+      onDelta: () => {},
+      onDone: () => {},
+      onError: () => {},
+    });
+    expect(controller).toBeInstanceOf(AbortController);
+  });
+
+  it('forwards delta chunks then signals done', async () => {
+    const result = await run(async () =>
+      streamResponse(['{"delta":"Hello"}\n', '{"delta":" world"}\n', '{"done":true}\n']),
+    );
+    expect(result.deltas).toEqual(['Hello', ' world']);
+    expect(result.done).toBe(true);
+  });
+
+  it('ignores blank and malformed lines', async () => {
+    const result = await run(async () =>
+      streamResponse(['\n', 'not-json\n', '{"delta":"ok"}\n', '{"done":true}\n']),
+    );
+    expect(result.deltas).toEqual(['ok']);
+    expect(result.done).toBe(true);
+  });
+
+  it('calls onDone when the stream ends without an explicit done flag', async () => {
+    const result = await run(async () => streamResponse(['{"delta":"hi"}\n']));
+    expect(result.deltas).toEqual(['hi']);
+    expect(result.done).toBe(true);
+  });
+
+  it('errors when the response has no body', async () => {
+    const result = await run(
+      async () => ({ ok: true, status: 200, body: null }) as unknown as Response,
+    );
+    expect(result.error).toBe('empty response body');
+  });
+
+  it('reports an error emitted inside the stream', async () => {
+    const result = await run(async () => streamResponse(['{"error":"boom in stream"}\n']));
+    expect(result.error).toBe('boom in stream');
+  });
+
+  it('surfaces network failures via onError', async () => {
+    const result = await run(async () => {
+      throw new Error('network down');
+    });
+    expect(result.error).toBe('network down');
+  });
+
+  it('swallows aborts without calling onError', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        throw err;
+      }),
+    );
+    const onError = vi.fn();
+    const onDone = vi.fn();
+    streamChat(MESSAGES, undefined, { onDelta: () => {}, onDone, onError });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('maps a 429 response to a rate-limit message', async () => {
+    const result = await run(
+      async () =>
+        ({
+          ok: false,
+          status: 429,
+          json: async () => ({ retryAfter: 30 }),
+        }) as unknown as Response,
+    );
+    expect(result.error).toMatch(/rate limited/i);
+    expect(result.error).toContain('30');
+  });
+
+  it('falls back to the HTTP status when the error body is not JSON', async () => {
+    const result = await run(
+      async () =>
+        ({
+          ok: false,
+          status: 500,
+          json: async () => {
+            throw new Error('not json');
+          },
+        }) as unknown as Response,
+    );
+    expect(result.error).toBe('HTTP 500');
+  });
+});

--- a/app/src/lib/motion.test.ts
+++ b/app/src/lib/motion.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  easeOutExpo,
+  fadeIn,
+  fadeUp,
+  routeTransition,
+  slideDown,
+  staggerContainer,
+} from './motion';
+
+describe('motion variants', () => {
+  it('fadeUp hides then shows with a vertical offset', () => {
+    expect(fadeUp.hidden).toMatchObject({ opacity: 0, y: 16 });
+    expect(fadeUp.show).toMatchObject({ opacity: 1, y: 0 });
+  });
+
+  it('fadeIn toggles opacity only', () => {
+    expect(fadeIn.hidden).toMatchObject({ opacity: 0 });
+    expect(fadeIn.show).toMatchObject({ opacity: 1 });
+  });
+
+  it('slideDown enters from above', () => {
+    expect(slideDown.hidden).toMatchObject({ opacity: 0, y: -16 });
+    expect(slideDown.show).toMatchObject({ opacity: 1, y: 0 });
+  });
+
+  it('easeOutExpo is a cubic-bezier tuple', () => {
+    expect(easeOutExpo).toEqual([0.22, 1, 0.36, 1]);
+  });
+
+  it('routeTransition defines initial / enter / exit states', () => {
+    expect(routeTransition.initial).toBeDefined();
+    expect(routeTransition.enter).toBeDefined();
+    expect(routeTransition.exit).toBeDefined();
+  });
+});
+
+describe('staggerContainer', () => {
+  it('uses the default stagger and delay', () => {
+    expect(staggerContainer().show).toMatchObject({
+      transition: { staggerChildren: 0.06, delayChildren: 0 },
+    });
+  });
+
+  it('honours custom stagger and delay values', () => {
+    expect(staggerContainer(0.1, 0.2).show).toMatchObject({
+      transition: { staggerChildren: 0.1, delayChildren: 0.2 },
+    });
+  });
+});

--- a/app/src/lib/works.test.ts
+++ b/app/src/lib/works.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { CATEGORY_LABEL, WORKS, filterByCategory, findWork, listCategories } from './works';
+
+describe('WORKS catalogue', () => {
+  it('exposes a non-empty list', () => {
+    expect(WORKS.length).toBeGreaterThan(0);
+  });
+
+  it('gives every work the expected shape', () => {
+    for (const work of WORKS) {
+      expect(work.id).toBeTruthy();
+      expect(work.title).toBeTruthy();
+      expect(['game', 'uiux', 'web', 'art', 'prototype']).toContain(work.category);
+      expect(['new', 'stable', 'wip']).toContain(work.status);
+      expect(typeof work.year).toBe('number');
+      expect(Array.isArray(work.tags)).toBe(true);
+    }
+  });
+
+  it('uses unique ids', () => {
+    const ids = WORKS.map((work) => work.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe('findWork', () => {
+  it('returns undefined for an undefined id', () => {
+    expect(findWork(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(findWork('does-not-exist')).toBeUndefined();
+  });
+
+  it('returns the matching work for a known id', () => {
+    const first = WORKS[0];
+    expect(findWork(first.id)).toEqual(first);
+  });
+});
+
+describe('filterByCategory', () => {
+  it('returns the full catalogue for "all"', () => {
+    expect(filterByCategory('all')).toEqual(WORKS);
+  });
+
+  it('returns only works in the requested category', () => {
+    const category = WORKS[0].category;
+    const filtered = filterByCategory(category);
+    expect(filtered.length).toBeGreaterThan(0);
+    expect(filtered.every((work) => work.category === category)).toBe(true);
+  });
+});
+
+describe('listCategories', () => {
+  it('always starts with "all"', () => {
+    expect(listCategories()[0]).toBe('all');
+  });
+
+  it('includes every category present in the catalogue, without duplicates', () => {
+    const categories = listCategories();
+    expect(new Set(categories).size).toBe(categories.length);
+    for (const work of WORKS) {
+      expect(categories).toContain(work.category);
+    }
+  });
+
+  it('sorts the categories after "all" alphabetically', () => {
+    const [, ...rest] = listCategories();
+    expect(rest).toEqual([...rest].sort());
+  });
+});
+
+describe('CATEGORY_LABEL', () => {
+  it('has a label for "all" and every category in use', () => {
+    expect(CATEGORY_LABEL.all).toBeTruthy();
+    for (const work of WORKS) {
+      expect(CATEGORY_LABEL[work.category]).toBeTruthy();
+    }
+  });
+});

--- a/app/src/routes/About.test.tsx
+++ b/app/src/routes/About.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { About } from './About';
+import { PROFILE } from '../lib/profile';
+
+function renderAbout() {
+  return render(
+    <MemoryRouter>
+      <About />
+    </MemoryRouter>,
+  );
+}
+
+describe('About route', () => {
+  it('renders the character status heading', () => {
+    renderAbout();
+    expect(screen.getByRole('heading', { level: 1, name: /status/i })).toBeInTheDocument();
+  });
+
+  it('shows the character name from the profile data', () => {
+    renderAbout();
+    expect(screen.getByText(PROFILE.name)).toBeInTheDocument();
+  });
+
+  it('renders the Skills & Tech Stack section with every group label', () => {
+    renderAbout();
+    expect(screen.getByRole('heading', { name: /skills & tech stack/i })).toBeInTheDocument();
+    for (const group of PROFILE.techStack) {
+      expect(screen.getByText(group.label)).toBeInTheDocument();
+    }
+  });
+
+  it('lists every passive perk', () => {
+    renderAbout();
+    for (const perk of PROFILE.perks) {
+      expect(screen.getByText(perk)).toBeInTheDocument();
+    }
+  });
+
+  it('links to the gallery quest log', () => {
+    renderAbout();
+    expect(screen.getByRole('link', { name: /see full quest log/i })).toHaveAttribute(
+      'href',
+      '/gallery',
+    );
+  });
+});

--- a/app/src/routes/Changelog.test.tsx
+++ b/app/src/routes/Changelog.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Changelog } from './Changelog';
+import { ACTIVITIES, groupByYear } from '../lib/activity';
+
+describe('Changelog route', () => {
+  it('renders the chronicles heading', () => {
+    render(<Changelog />);
+    expect(screen.getByRole('heading', { level: 1, name: /chronicles/i })).toBeInTheDocument();
+  });
+
+  it('highlights the most recent activity', () => {
+    render(<Changelog />);
+    expect(screen.getAllByText(ACTIVITIES[0].title).length).toBeGreaterThan(0);
+  });
+
+  it('renders a heading for every year group', () => {
+    render(<Changelog />);
+    for (const group of groupByYear()) {
+      expect(screen.getByRole('heading', { name: String(group.year) })).toBeInTheDocument();
+    }
+  });
+
+  it('renders the connect section with the GitHub profile link', () => {
+    render(<Changelog />);
+    expect(screen.getByText(/connect with the party/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /source code/i })).toHaveAttribute(
+      'href',
+      'https://github.com/shiyow5',
+    );
+  });
+});

--- a/app/src/routes/Gallery.test.tsx
+++ b/app/src/routes/Gallery.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { Gallery } from './Gallery';
+import { CATEGORY_LABEL, WORKS } from '../lib/works';
+
+function renderGallery() {
+  return render(
+    <MemoryRouter>
+      <Gallery />
+    </MemoryRouter>,
+  );
+}
+
+describe('Gallery route', () => {
+  it('renders the archive heading', () => {
+    renderGallery();
+    expect(
+      screen.getByRole('heading', { level: 1, name: /archive of completed tasks/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders every work by default', () => {
+    renderGallery();
+    for (const work of WORKS) {
+      expect(screen.getByText(work.title)).toBeInTheDocument();
+    }
+  });
+
+  it('links each card to its detail route', () => {
+    renderGallery();
+    const first = WORKS[0];
+    const link = screen.getByRole('link', { name: new RegExp(first.title, 'i') });
+    expect(link).toHaveAttribute('href', `/works/${first.id}`);
+  });
+
+  it('narrows the list when a category filter is selected', async () => {
+    const user = userEvent.setup();
+    renderGallery();
+
+    const category = WORKS[0].category;
+    const inCategory = WORKS.filter((work) => work.category === category);
+    const outOfCategory = WORKS.find((work) => work.category !== category);
+
+    await user.click(
+      screen.getByRole('button', { name: new RegExp(CATEGORY_LABEL[category], 'i') }),
+    );
+
+    expect(
+      screen.getByRole('button', { name: new RegExp(CATEGORY_LABEL[category], 'i') }),
+    ).toHaveAttribute('aria-pressed', 'true');
+    for (const work of inCategory) {
+      expect(screen.getByText(work.title)).toBeInTheDocument();
+    }
+    if (outOfCategory) {
+      expect(screen.queryByText(outOfCategory.title)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/app/src/routes/NotFound.test.tsx
+++ b/app/src/routes/NotFound.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { NotFound } from './NotFound';
+
+function renderNotFound() {
+  return render(
+    <MemoryRouter>
+      <NotFound />
+    </MemoryRouter>,
+  );
+}
+
+describe('NotFound route', () => {
+  it('shows the 404 heading', () => {
+    renderNotFound();
+    expect(screen.getByRole('heading', { level: 1, name: '404' })).toBeInTheDocument();
+  });
+
+  it('offers a link back to the atelier home', () => {
+    renderNotFound();
+    expect(screen.getByRole('link', { name: /return to atelier/i })).toHaveAttribute('href', '/');
+  });
+});

--- a/app/src/routes/WorkDetail.test.tsx
+++ b/app/src/routes/WorkDetail.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { WorkDetail } from './WorkDetail';
+import { WORKS } from '../lib/works';
+
+function renderWorkDetail(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/works/:id" element={<WorkDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('WorkDetail route', () => {
+  it('renders the matching work', () => {
+    const work = WORKS[0];
+    renderWorkDetail(`/works/${work.id}`);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: new RegExp(work.title, 'i') }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(work.tagline)).toBeInTheDocument();
+    for (const tech of work.tech) {
+      expect(screen.getByText(tech)).toBeInTheDocument();
+    }
+  });
+
+  it('shows a not-found state for an unknown id', () => {
+    renderWorkDetail('/works/totally-unknown-id');
+
+    expect(screen.getByRole('heading', { name: /work not found/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /back to gallery/i })).toHaveAttribute(
+      'href',
+      '/gallery',
+    );
+  });
+
+  it('exposes the external code link from the work data', () => {
+    const work = WORKS.find((candidate) => candidate.links.github);
+    expect(work).toBeDefined();
+    if (!work?.links.github) return;
+
+    renderWorkDetail(`/works/${work.id}`);
+    expect(screen.getByRole('link', { name: /code/i })).toHaveAttribute('href', work.links.github);
+  });
+});


### PR DESCRIPTION
## 概要
ユニットテストを **3 件 → 64 件** に拡充し、カバレッジを大幅に向上させました。

| 指標 | Before | After |
| --- | --- | --- |
| Statements | 68.0% | **88.9%** |
| Lines | 72.5% | **91.1%** |
| Functions | 56.5% | **87.2%** |
| Branches | 45.2% | 72.3% |

主要 3 指標で 80% を達成。Branches は `WanderingCharacter`（アニメ部品）と reduced-motion フォールバックが主因で 80% 未達です。

## 追加したテスト
- **lib**: `works` / `activity` / `motion` / `chat`（`streamChat` を fetch モックでストリーミング検証）
- **routes**: `About` / `Gallery`（カテゴリフィルタ） / `WorkDetail`（id 解決・not-found） / `Changelog` / `NotFound`
- **components**: `Footer` / `TopNav`（ハンバーガー開閉・Escape クローズ）

## テスト計画
- [x] `npm run test` — 64 passed
- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npm run format:check` — green
- [x] `npm run build` — green