### PR TITLE
fix(ui): Changelog コントラスト修正 + Footer リンク修正 + Recent Loot を実データ化

### DIFF
--- a/app/src/components/layout/Footer.tsx
+++ b/app/src/components/layout/Footer.tsx
@@ -7,7 +7,7 @@ export function Footer() {
         </div>
         <div className="flex gap-8">
           <a
-            href="https://github.com"
+            href="https://github.com/shiyow5"
             target="_blank"
             rel="noreferrer"
             className="text-xs uppercase font-medium text-tertiary opacity-70 hover:opacity-100 hover:text-primary transition-all tracking-widest"

--- a/app/src/routes/Changelog.tsx
+++ b/app/src/routes/Changelog.tsx
@@ -135,7 +135,10 @@ export function Changelog() {
         </div>
 
         <aside className="lg:col-span-4 space-y-6">
-          <section className="bg-tertiary text-on-tertiary pixel-border border-[#502f09] p-6">
+          <section
+            className="bg-tertiary text-on-tertiary pixel-border border-[#502f09] p-6"
+            style={{ backgroundColor: 'var(--color-tertiary)' }}
+          >
             <div className="flex items-start justify-between mb-6">
               <div>
                 <div className="text-[10px] uppercase font-black tracking-widest opacity-80 mb-1">

--- a/app/src/routes/Home.test.tsx
+++ b/app/src/routes/Home.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { Home } from './Home';
+import { WORKS } from '../lib/works';
 
 function renderHome() {
   return render(
@@ -26,5 +27,12 @@ describe('Home route', () => {
     renderHome();
     const cta = screen.getByRole('link', { name: /start quest/i });
     expect(cta).toHaveAttribute('href', '/gallery');
+  });
+
+  it('features real works in Recent Loot, linking to their detail pages', () => {
+    renderHome();
+    const first = WORKS[0];
+    const link = screen.getByRole('link', { name: new RegExp(first.title, 'i') });
+    expect(link).toHaveAttribute('href', `/works/${first.id}`);
   });
 });

--- a/app/src/routes/Home.tsx
+++ b/app/src/routes/Home.tsx
@@ -10,6 +10,7 @@ import {
   CATEGORY_LABEL,
   formatDate,
 } from '../lib/activity';
+import { WORKS, CATEGORY_LABEL as WORK_CATEGORY_LABEL } from '../lib/works';
 const CHARACTER_SRC = '/characters/shiyow.png';
 const ROOM_SRC = '/rooms/simple_room.png';
 
@@ -22,32 +23,8 @@ const SIDE_NAV = [
 const INVENTORY_GROUPS = PROFILE.techStack.slice(0, 6);
 const LATEST_ACTIVITY = ACTIVITIES[0];
 
-const FEATURED = [
-  {
-    id: 'aether-drift',
-    tag: 'Concept Art',
-    title: 'The Neon Dungeon',
-    desc: 'A cyberpunk-inspired dungeon crawler asset pack featuring 500+ handcrafted elements.',
-    xp: 'Gold Earned · 1,200',
-    size: 'lg',
-  },
-  {
-    id: 'neon-circuit',
-    tag: '[Animation]',
-    title: 'Sprite Sheets',
-    desc: '',
-    xp: '',
-    size: 'sm',
-  },
-  {
-    id: 'loot-logic',
-    tag: '[UI/UX]',
-    title: 'Menu Systems',
-    desc: '',
-    xp: '',
-    size: 'sm',
-  },
-];
+// Recent Loot bento: the three most recent works, wired to real catalogue data.
+const FEATURED = WORKS.slice(0, 3);
 
 export function Home() {
   return (
@@ -206,18 +183,25 @@ export function Home() {
               to={`/works/${FEATURED[0].id}`}
               className="h-full bg-surface-container-lowest pixel-border flex flex-col hover:-translate-y-1 transition-transform"
             >
-              <div className="h-60 md:h-64 bg-gradient-to-br from-primary-container to-secondary-container border-b-4 border-tertiary" />
+              <div className="h-60 md:h-64 border-b-4 border-tertiary overflow-hidden">
+                <img
+                  src={FEATURED[0].cover}
+                  alt={FEATURED[0].title}
+                  className="w-full h-full object-cover"
+                  draggable={false}
+                />
+              </div>
               <div className="p-6 flex-grow flex flex-col">
                 <span className="inline-block px-2 py-1 bg-secondary-container text-on-secondary-container text-[10px] font-black uppercase tracking-widest mb-4 w-fit">
-                  {FEATURED[0].tag}
+                  {WORK_CATEGORY_LABEL[FEATURED[0].category]}
                 </span>
                 <h3 className="text-2xl font-black uppercase mb-2 text-on-surface">
                   {FEATURED[0].title}
                 </h3>
-                <p className="text-sm text-on-surface-variant mb-6">{FEATURED[0].desc}</p>
+                <p className="text-sm text-on-surface-variant mb-6">{FEATURED[0].tagline}</p>
                 <div className="mt-auto flex justify-between items-center">
                   <span className="text-xs font-black uppercase text-tertiary tracking-widest">
-                    {FEATURED[0].xp}
+                    v{FEATURED[0].version} · {FEATURED[0].year}
                   </span>
                   <ArrowRight size={20} className="text-primary" />
                 </div>
@@ -226,16 +210,23 @@ export function Home() {
           </Reveal>
 
           {/* Small 1 & 2 */}
-          {FEATURED.slice(1).map((f, i) => (
-            <Reveal key={f.id} delay={0.08 * (i + 1)}>
+          {FEATURED.slice(1).map((work, i) => (
+            <Reveal key={work.id} delay={0.08 * (i + 1)}>
               <Link
-                to={`/works/${f.id}`}
+                to={`/works/${work.id}`}
                 className="block h-full bg-surface-container-lowest pixel-border p-4 hover:-translate-y-1 transition-transform"
               >
-                <div className="h-32 bg-gradient-to-br from-tertiary-container to-primary-container mb-4 border-2 border-outline-variant" />
-                <h4 className="font-black uppercase text-sm mb-1 text-on-surface">{f.title}</h4>
+                <div className="h-32 mb-4 border-2 border-outline-variant overflow-hidden">
+                  <img
+                    src={work.cover}
+                    alt={work.title}
+                    className="w-full h-full object-cover"
+                    draggable={false}
+                  />
+                </div>
+                <h4 className="font-black uppercase text-sm mb-1 text-on-surface">{work.title}</h4>
                 <p className="text-xs text-on-surface-variant uppercase font-black tracking-widest">
-                  {f.tag}
+                  {WORK_CATEGORY_LABEL[work.category]}
                 </p>
               </Link>
             </Reveal>


### PR DESCRIPTION
## 概要
スクリーンショット + 計算スタイル検証による UI 監査で見つかった欠陥とプレースホルダーを修正します。

## 変更内容

### 1. fix: Changelog「Most Recent」カードのコントラスト不良
`.pixel-border`（`index.css:159`）が `background-color: var(--color-surface)` を強制し `bg-tertiary` を上書きしていたため、カードが **白背景 + 白文字（`text-on-tertiary`）で内容が不可視**でした。
- Playwright で計算スタイルを確認: bg=`rgb(251,249,244)` cream / text=`rgb(255,247,244)` white
- 背景色を tertiary に固定 → 修正後 bg=`rgb(126,87,46)` brown で可読に回復

### 2. fix: Footer の GitHub リンク
汎用 `https://github.com` → 本人プロフィール `https://github.com/shiyow5`

### 3. feat: Home「Recent Loot」を実 works データに接続
ハードコードのダミー（"The Neon Dungeon" / "Gold Earned · 1,200" / グラデブロック等）を撤廃し、`works.json` の最新 3 作品を**実タイトル・実カバー画像・実カテゴリ・実リンク**で表示。サイト内で唯一データ未接続だったセクションを解消。

## 未対応（実 URL 待ち）
以下は実 URL の提供後に対応予定:
- Footer の Itch.io / Contact（`#`）
- Changelog の Discord / X（`#`）
- `works.json` の `example.com` デモ URL 4 件

## テスト計画
- [x] `npm run typecheck` / `lint` / `format:check` / `build` — green
- [x] Playwright で Changelog カードの背景色が brown に直ったことを確認
- [x] Playwright で Recent Loot が実 works（AETHER DRIFT / NEON CIRCUIT / LOOT LOGIC）を表示することを確認