### PR TITLE
fix(links): X リンクを反映し URL 未定のソーシャルリンクを削除

### DIFF
--- a/app/src/components/layout/Footer.test.tsx
+++ b/app/src/components/layout/Footer.test.tsx
@@ -8,17 +8,20 @@ describe('Footer', () => {
     expect(screen.getByText(/handcrafted with pixels/i)).toBeInTheDocument();
   });
 
-  it('renders the GitHub, Itch.io and Contact links', () => {
+  it('renders the GitHub and X social links', () => {
     render(<Footer />);
     expect(screen.getByRole('link', { name: /github/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /itch\.io/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /contact/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'X' })).toBeInTheDocument();
   });
 
-  it('points the GitHub link at github.com', () => {
+  it('points the social links at the real profiles', () => {
     render(<Footer />);
-    const href = screen.getByRole('link', { name: /github/i }).getAttribute('href');
-    expect(href).toContain('github.com');
+    expect(screen.getByRole('link', { name: /github/i }).getAttribute('href')).toContain(
+      'github.com/shiyow5',
+    );
+    expect(screen.getByRole('link', { name: 'X' }).getAttribute('href')).toContain(
+      'x.com/twinS_KNSN1415',
+    );
   });
 
   it('shows the server-online status indicator', () => {

--- a/app/src/components/layout/Footer.tsx
+++ b/app/src/components/layout/Footer.tsx
@@ -15,16 +15,12 @@ export function Footer() {
             GitHub
           </a>
           <a
-            href="#"
+            href="https://x.com/twinS_KNSN1415"
+            target="_blank"
+            rel="noreferrer"
             className="text-xs uppercase font-medium text-tertiary opacity-70 hover:opacity-100 hover:text-primary transition-all tracking-widest"
           >
-            Itch.io
-          </a>
-          <a
-            href="#"
-            className="text-xs uppercase font-medium text-tertiary opacity-70 hover:opacity-100 hover:text-primary transition-all tracking-widest"
-          >
-            Contact
+            X
           </a>
         </div>
         <div className="text-[10px] font-black uppercase text-secondary flex items-center gap-2 tracking-widest">

--- a/app/src/routes/Changelog.test.tsx
+++ b/app/src/routes/Changelog.test.tsx
@@ -29,4 +29,12 @@ describe('Changelog route', () => {
       'https://github.com/shiyow5',
     );
   });
+
+  it('links the Broadcast entry to the real X profile', () => {
+    render(<Changelog />);
+    expect(screen.getByRole('link', { name: /broadcast/i })).toHaveAttribute(
+      'href',
+      'https://x.com/twinS_KNSN1415',
+    );
+  });
 });

--- a/app/src/routes/Changelog.tsx
+++ b/app/src/routes/Changelog.tsx
@@ -209,15 +209,9 @@ export function Changelog() {
                   icon: 'code',
                 },
                 {
-                  label: 'Guild Hall',
-                  detail: 'Discord · 調整中',
-                  href: '#',
-                  icon: 'forum',
-                },
-                {
                   label: 'Broadcast',
-                  detail: 'X / Twitter',
-                  href: '#',
+                  detail: 'X · @twinS_KNSN1415',
+                  href: 'https://x.com/twinS_KNSN1415',
                   icon: 'campaign',
                 },
               ].map((link) => (


### PR DESCRIPTION
## 概要
ユーザー提供の X アカウントを反映し、URL が未定だったプレースホルダーリンク（`#`）を整理しました。

## 変更内容
- **X (@twinS_KNSN1415)** を実 URL `https://x.com/twinS_KNSN1415` で接続
  - Changelog の「Broadcast」枠
  - Footer に X リンクを追加
- **削除**（URL 未定・後日復活可能）
  - Footer: Itch.io / Contact（`#`）
  - Changelog: Discord「Guild Hall」（`#`）
- GitHub は #47 で `shiyow5` に修正済み

## 据え置き（後日対応）
- `works.json` の play / demo リンクは**全項目が仮データ**のため今回は変更せず

## テスト計画
- [x] Footer / Changelog のテストを実態に合わせて更新
- [x] `npm run typecheck` / `lint` / `format:check` / `build` — green
- [x] `npm run test` — 66 passed
- [x] Playwright で Connect セクション・Footer のレイアウトを目視確認