### PR TITLE
fix(a11y,ux): レビュー指摘のクイックウィン6件

### DIFF
--- a/app/src/components/chat/ChatWidget.tsx
+++ b/app/src/components/chat/ChatWidget.tsx
@@ -177,9 +177,9 @@ export function ChatWidget() {
               ))}
             </div>
 
-            {!TURNSTILE_SITEKEY && (
+            {import.meta.env.DEV && !TURNSTILE_SITEKEY && (
               <div className="px-4 py-1 text-[10px] font-black uppercase tracking-widest bg-error-container text-on-error border-t-2 border-error">
-                Turnstile 未設定 — 保護なしで動作中
+                Turnstile 未設定 — 保護なしで動作中（開発時のみ表示）
               </div>
             )}
 
@@ -194,7 +194,7 @@ export function ChatWidget() {
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 placeholder="メッセージを入力..."
-                className="flex-1 bg-surface-container-lowest border-2 border-outline px-3 py-2 text-sm focus:border-primary focus:border-4 outline-none transition-all"
+                className="flex-1 bg-surface-container-lowest border-2 border-outline px-3 py-2 text-base focus:border-primary focus:border-4 outline-none transition-all"
                 maxLength={500}
                 disabled={sending}
               />

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -82,6 +82,14 @@ body {
   color: var(--color-on-primary);
 }
 
+/* Keyboard focus indicator (WCAG 2.4.7).
+   outline-offset places the ring outside the element, on the page background,
+   so a primary-blue ring keeps contrast even over coloured/pixel-bordered controls. */
+:focus-visible {
+  outline: 3px solid var(--color-primary);
+  outline-offset: 3px;
+}
+
 /* ==============================================================
    Background Effects (retro-bg + scanlines + particles)
    ============================================================== */
@@ -308,4 +316,16 @@ img.pixelated {
 }
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-tertiary-dim);
+}
+
+/* ==============================================================
+   Reduced motion — silence decorative CSS animations too
+   (JS/motion already honours useReducedMotion; this covers pure CSS)
+   ============================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .scanlines,
+  .pixel-particles .particle,
+  .animate-pulse {
+    animation: none !important;
+  }
 }

--- a/app/src/routes/Home.tsx
+++ b/app/src/routes/Home.tsx
@@ -47,7 +47,7 @@ export function Home() {
                   Profile
                 </p>
                 <p className="text-sm font-black uppercase text-on-tertiary-container">
-                  shiyow · Lvl 99
+                  shiyow · Lvl {PROFILE.level}
                 </p>
               </div>
             </div>

--- a/app/src/routes/WorkDetail.tsx
+++ b/app/src/routes/WorkDetail.tsx
@@ -174,8 +174,8 @@ export function WorkDetail() {
               Loot Drop
             </div>
             <p className="text-xs font-bold text-on-tertiary-container leading-snug mt-2">
-              コラボ・コミッションのご相談はチャット右下の shiyow クローン、または Contact
-              リンクからどうぞ。
+              コラボ・コミッションのご相談は、右下の shiyow クローン（AI
+              チャット）にお声がけください。
             </p>
           </section>
         </aside>


### PR DESCRIPTION
多視点UXレビューで挙がった指摘のうち、**ポジショニングに依存しない安全な6件**を実装。

## 変更
- **a11y** グローバル `:focus-visible` リング追加（WCAG 2.4.7 / キーボード可視化）
- **a11y** `prefers-reduced-motion` で scanlines / particles / animate-pulse を停止
- **ux** WorkDetail の存在しない「Contactリンク」案内 → 実在の導線（shiyowクローン）に修正
- **ux** Home のレベル表記を `PROFILE.level` に統一（Lvl 99→28 の矛盾解消）
- **ux** チャットの Turnstile 警告を `import.meta.env.DEV` 時のみ表示（本番では非表示）
- **ux** チャット入力を 16px 化（iOS 自動ズーム防止）

## テスト
- [x] typecheck / lint / format / build — green
- [x] test — 66 passed