### PR TITLE
feat: AIエンジニアとしてのリポジショニング

### DIFF
--- a/app/e2e/smoke.spec.ts
+++ b/app/e2e/smoke.spec.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 test.describe('Smoke', () => {
   test('home renders hero + Recent Loot + chat widget FAB', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByRole('heading', { level: 1, name: /level 1: home/i })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /shiyow/i })).toBeVisible();
     await expect(page.getByRole('heading', { level: 2, name: /recent loot/i })).toBeVisible();
     await expect(page.getByRole('button', { name: /open chat/i })).toBeVisible();
   });

--- a/app/src/components/chat/ChatWidget.tsx
+++ b/app/src/components/chat/ChatWidget.tsx
@@ -15,7 +15,8 @@ interface DisplayMessage extends ChatMessage {
 const GREETING: DisplayMessage = {
   id: 'greeting',
   role: 'assistant',
-  content: 'やぁ旅人！ shiyow のクローンです。サイト案内、よろしく。何でも聞いて。',
+  content:
+    'shiyow の AI クローンです（Gemini 製）。経歴・スキル・作ったもの、何でも聞いてください。',
 };
 
 export function ChatWidget() {
@@ -32,6 +33,13 @@ export function ChatWidget() {
 
   useEffect(() => {
     return () => abortRef.current?.abort();
+  }, []);
+
+  // Allow other components (e.g. the Home hero CTA) to open the chat.
+  useEffect(() => {
+    const openChat = () => setOpen(true);
+    window.addEventListener('shiyow:open-chat', openChat);
+    return () => window.removeEventListener('shiyow:open-chat', openChat);
   }, []);
 
   const handleSend = () => {
@@ -102,7 +110,7 @@ export function ChatWidget() {
               className="pixel-border bg-surface-container-lowest p-3 max-w-[220px]"
             >
               <p className="text-[11px] font-black uppercase text-on-surface leading-snug">
-                Hey Traveler! 何か聞いてみる?
+                shiyow の AI クローンに聞いてみる?
               </p>
               <div className="absolute -bottom-2 right-6 w-4 h-4 bg-surface-container-lowest border-r-4 border-b-4 border-tertiary rotate-45" />
             </motion.div>

--- a/app/src/data/profile.json
+++ b/app/src/data/profile.json
@@ -1,11 +1,11 @@
 {
   "name": "Shiyow",
-  "classTitle": "Pixel Craftsperson / UI Engineer",
+  "classTitle": "AI Engineer / LLM・Agent Developer",
   "level": 28,
   "xp": 12450,
   "xpNext": 15000,
   "location": "Digital Highlands, JP",
-  "bioQuote": "デジタル高原の職人。ピクセルの形と UX の流れを磨き続けてはや何月。今は広い Web 平原を旅しながら、帰宅した時みたいに落ち着く体験を作っています。",
+  "bioQuote": "LLM とエージェントで動くプロダクトを作る AI エンジニア。モデル選定・RAG・エージェント設計の実装から、手触りの良い UI まで一気通貫で仕上げるのが好きです。",
   "stats": [
     { "label": "HP", "value": 92, "max": 100, "color": "secondary" },
     { "label": "Focus", "value": 74, "max": 100, "color": "primary" },
@@ -13,22 +13,22 @@
   ],
   "techStack": [
     {
+      "id": "ai",
+      "label": "AI & Agents",
+      "icon": "smart_toy",
+      "items": ["Gemini 2.0 Flash", "Claude", "LangChain", "RAG", "Vectorize (Workers AI)"]
+    },
+    {
       "id": "languages",
       "label": "Languages",
       "icon": "code",
-      "items": ["TypeScript", "JavaScript", "Python", "Go", "SQL"]
+      "items": ["Python", "TypeScript", "JavaScript", "Go", "SQL"]
     },
     {
       "id": "frameworks",
       "label": "Frameworks & Runtime",
       "icon": "deployed_code",
-      "items": ["React 19", "Vite 6", "Tailwind CSS v4", "Motion", "React Router", "Node.js"]
-    },
-    {
-      "id": "design",
-      "label": "Design & Pixel Art",
-      "icon": "brush",
-      "items": ["Figma", "FigJam", "Aseprite", "Photoshop"]
+      "items": ["React 19", "Vite 8", "Tailwind CSS v4", "Motion", "React Router", "Node.js"]
     },
     {
       "id": "cloud",
@@ -37,28 +37,28 @@
       "items": ["Cloudflare Pages", "Workers", "D1", "R2", "KV", "GCP", "Vercel"]
     },
     {
-      "id": "ai",
-      "label": "AI & Agents",
-      "icon": "smart_toy",
-      "items": ["Gemini 2.0 Flash", "Claude", "LangChain", "Vectorize (Workers AI)"]
+      "id": "tools",
+      "label": "Tools",
+      "icon": "build",
+      "items": ["VS Code", "Git", "gh CLI", "tmux", "Wrangler"]
+    },
+    {
+      "id": "design",
+      "label": "Design & Pixel Art",
+      "icon": "brush",
+      "items": ["Figma", "FigJam", "Aseprite", "Photoshop"]
     },
     {
       "id": "gamedev",
       "label": "Game Dev",
       "icon": "sports_esports",
       "items": ["Unity", "Godot"]
-    },
-    {
-      "id": "tools",
-      "label": "Tools",
-      "icon": "build",
-      "items": ["VS Code", "Git", "gh CLI", "tmux", "Wrangler"]
     }
   ],
   "perks": [
-    "Passive: 新しいピクセルフォントを見ると HP +5",
-    "Passive: 太ボーダー+角丸0pxに耐性",
-    "Active: ダークモード → ライトモード往復で CSS 変数を自動整理"
+    "Passive: 自分のクローン AI をサイトに住まわせている",
+    "Passive: モデル選定とコスト最適化が習慣",
+    "Active: プロトタイプから本番デプロイまで一人で通す"
   ],
   "history": [
     {

--- a/app/src/routes/About.tsx
+++ b/app/src/routes/About.tsx
@@ -174,7 +174,7 @@ export function About() {
 
             <footer className="mt-8 border-t-4 border-outline-variant pt-6">
               <h3 className="font-black uppercase tracking-widest text-sm text-tertiary mb-3">
-                Passive Perks
+                Passive Perks · Strengths
               </h3>
               <ul className="space-y-2">
                 {PROFILE.perks.map((perk) => (

--- a/app/src/routes/Gallery.tsx
+++ b/app/src/routes/Gallery.tsx
@@ -33,7 +33,7 @@ export function Gallery() {
       <header className="mb-10">
         <div className="inline-block bg-tertiary-container px-5 py-1.5 border-4 border-tertiary mb-4">
           <span className="font-black text-on-tertiary-container uppercase tracking-tighter text-sm">
-            Quest Log
+            Quest Log · Works
           </span>
         </div>
         <h1 className="text-5xl md:text-7xl font-black uppercase tracking-tighter text-tertiary leading-none">

--- a/app/src/routes/Home.test.tsx
+++ b/app/src/routes/Home.test.tsx
@@ -13,9 +13,15 @@ function renderHome() {
 }
 
 describe('Home route', () => {
-  it('shows the hero heading', () => {
+  it('shows the hero with the name and AI Engineer role', () => {
     renderHome();
-    expect(screen.getByRole('heading', { level: 1, name: /level 1: home/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: /shiyow/i })).toBeInTheDocument();
+    expect(screen.getByText(/ai engineer/i)).toBeInTheDocument();
+  });
+
+  it('offers a CTA to talk to the AI clone', () => {
+    renderHome();
+    expect(screen.getByRole('button', { name: /クローンと話す/ })).toBeInTheDocument();
   });
 
   it('renders the Recent Loot section', () => {

--- a/app/src/routes/Home.tsx
+++ b/app/src/routes/Home.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { ArrowRight, Swords, User, LayoutGrid } from 'lucide-react';
+import { ArrowRight, Swords, User, LayoutGrid, Bot } from 'lucide-react';
 import { WanderingCharacter } from '../components/pixel/WanderingCharacter';
 import { Reveal } from '../components/motion/Reveal';
 import { PROFILE } from '../lib/profile';
@@ -27,6 +27,8 @@ const LATEST_ACTIVITY = ACTIVITIES[0];
 const FEATURED = WORKS.slice(0, 3);
 
 export function Home() {
+  const openChat = () => window.dispatchEvent(new CustomEvent('shiyow:open-chat'));
+
   return (
     <section className="max-w-[1440px] mx-auto px-6 py-12 md:py-20 relative">
       {/* Hero */}
@@ -74,10 +76,27 @@ export function Home() {
         {/* Center Stage */}
         <div className="lg:col-span-6 order-1 lg:order-2 flex flex-col items-center">
           <div className="mb-8 text-center">
-            <h1 className="text-5xl md:text-7xl font-black uppercase tracking-tighter text-tertiary mb-2">
+            <span className="inline-block bg-tertiary-container px-3 py-1 border-2 border-tertiary text-[10px] font-black uppercase tracking-widest text-on-tertiary-container mb-4">
               Level 1: Home
+            </span>
+            <h1 className="text-5xl md:text-7xl font-black uppercase tracking-tighter text-tertiary leading-none">
+              Shiyow
             </h1>
-            <div className="h-2 w-32 bg-primary mx-auto" />
+            <p className="text-xl md:text-2xl font-black uppercase tracking-tight text-primary mt-1">
+              AI Engineer
+            </p>
+            <p className="text-sm md:text-base text-on-surface-variant max-w-md mx-auto mt-4 normal-case">
+              LLM アプリ・AI エージェント・ML をプロダクトとして実装します。
+            </p>
+            <div className="flex flex-wrap gap-3 justify-center mt-6">
+              <button type="button" onClick={openChat} className="pixel-button">
+                <Bot size={16} /> AI クローンと話す
+              </button>
+              <Link to="/gallery" className="pixel-button pixel-button--tertiary">
+                実績を見る
+              </Link>
+            </div>
+            <div className="h-2 w-32 bg-primary mx-auto mt-8" />
           </div>
 
           <div className="relative w-full max-w-[600px] aspect-square bg-surface-container-high pixel-border overflow-hidden">
@@ -131,7 +150,7 @@ export function Home() {
 
             <div>
               <h3 className="text-xs font-black uppercase tracking-widest text-tertiary border-b-2 border-tertiary pb-1 mb-3">
-                Inventory
+                Inventory · Tech Stack
               </h3>
               <div className="grid grid-cols-3 gap-2">
                 {INVENTORY_GROUPS.map((group) => (
@@ -164,9 +183,14 @@ export function Home() {
       {/* Featured — Recent Loot bento */}
       <section className="mt-24 md:mt-32">
         <Reveal as="header" className="flex items-end justify-between mb-8 md:mb-12">
-          <h2 className="text-3xl md:text-4xl font-black uppercase tracking-tighter text-on-surface">
-            Recent Loot
-          </h2>
+          <div>
+            <span className="block text-[10px] font-black uppercase tracking-widest text-on-surface-variant mb-1">
+              Selected Works
+            </span>
+            <h2 className="text-3xl md:text-4xl font-black uppercase tracking-tighter text-on-surface">
+              Recent Loot
+            </h2>
+          </div>
           <div className="hidden md:block h-1 flex-grow mx-8 bg-surface-container-highest" />
           <Link
             to="/gallery"

--- a/app/src/routes/WorkDetail.tsx
+++ b/app/src/routes/WorkDetail.tsx
@@ -125,7 +125,7 @@ export function WorkDetail() {
 
           <article className="bg-surface-container-lowest pixel-border p-6 md:p-8">
             <h2 className="text-xl font-black uppercase tracking-tight text-tertiary mb-4">
-              Quest Log
+              Quest Log · About
             </h2>
             <p className="text-on-surface leading-relaxed whitespace-pre-line">
               {work.description}
@@ -171,7 +171,7 @@ export function WorkDetail() {
 
           <section className="pixel-border bg-tertiary-container p-5 relative">
             <div className="absolute -top-3 left-4 bg-tertiary text-on-tertiary px-3 py-1 text-[10px] font-black uppercase tracking-widest">
-              Loot Drop
+              Loot Drop · Contact
             </div>
             <p className="text-xs font-bold text-on-tertiary-container leading-snug mt-2">
               コラボ・コミッションのご相談は、右下の shiyow クローン（AI


### PR DESCRIPTION
ユーザー（AIエンジニア）のポジショニングに合わせ、打ち出しを UI/ピクセル職人から **AIエンジニア**へ転換。ピクセル世界観は装飾として維持しつつ、中身を AI に寄せる方針（決定: ヒーローは「AI前面・テーマは装飾」／用語は二層表記）。

## 変更
- **Home ヒーロー刷新**: 最大見出しを `SHIYOW / AI ENGINEER` ＋価値提案（LLMアプリ・AIエージェント・ML）に。`LEVEL 1: HOME` は小ラベルへ降格
- **ヒーローCTA「AIクローンと話す」**を追加し `CustomEvent('shiyow:open-chat')` でチャット起動（ChatWidget が購読）。看板資産のチャットを **AIクローン**として前面化
- **profile.json**: 肩書き→`AI Engineer / LLM・Agent Developer`、techStack を **AI & Agents 先頭**へ並べ替え、bio/perks を AI 寄りに、Vite 6→8 修正
- **二層ラベリング**: Inventory·Tech Stack / Recent Loot+Selected Works / Quest Log·Works·About / Loot Drop·Contact / Passive Perks·Strengths

## 未対応（あなたの素材/決定待ち）
- **連絡導線(mailto)**: メールアドレス未取得のため未実装（X はリンク済み）
- **works の実データ化**: shiyow クローン＋あなたのAI/MLプロジェクトの実データ待ち

## テスト
- [x] typecheck / lint / format / build — green
- [x] test — 67 passed（Home/smoke のヒーロー検証を更新）
- [x] Playwright でヒーロー→チャット起動・スキル並び替え・二層ラベルを目視確認