### PR TITLE
perf,a11y,seo: コード分割 + フォーカス/タイトル管理 + AI寄りメタ

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,14 +6,21 @@
     <meta name="theme-color" content="#fbf9f4" />
     <meta
       name="description"
-      content="shiyow.dev — 16-Bit Atelier style portfolio. Pixel art UI meets editorial craft."
+      content="shiyow — AI エンジニア。LLM アプリ・AI エージェント・ML をプロダクトとして実装します。サイト内では自作のクローン AI と話せます。"
     />
-    <meta property="og:title" content="SHIYOW — The 16-Bit Atelier" />
+    <meta property="og:title" content="Shiyow — AI Engineer" />
     <meta
       property="og:description"
-      content="Pixel art UI portfolio. Games, illustrations, and web crafts."
+      content="LLM アプリ・AI エージェント・ML をプロダクトとして実装する AI エンジニア。自作のクローン AI と話せるポートフォリオ。"
     />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://shiyow.dev/" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Shiyow — AI Engineer" />
+    <meta
+      name="twitter:description"
+      content="LLM アプリ・AI エージェント・ML を実装する AI エンジニア。自作のクローン AI と話せるポートフォリオ。"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -24,7 +31,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=block"
     />
-    <title>SHIYOW — The 16-Bit Atelier</title>
+    <title>Shiyow — AI Engineer</title>
   </head>
   <body>
     <div id="root"></div>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,11 +1,17 @@
+import { lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { Layout } from './components/layout/Layout';
 import { Home } from './routes/Home';
-import { About } from './routes/About';
-import { Gallery } from './routes/Gallery';
-import { WorkDetail } from './routes/WorkDetail';
-import { Changelog } from './routes/Changelog';
-import { NotFound } from './routes/NotFound';
+
+// Home stays eager (it is the landing route); the rest are code-split so the
+// first paint only ships the home + shared chunks instead of every route.
+const About = lazy(() => import('./routes/About').then((m) => ({ default: m.About })));
+const Gallery = lazy(() => import('./routes/Gallery').then((m) => ({ default: m.Gallery })));
+const WorkDetail = lazy(() =>
+  import('./routes/WorkDetail').then((m) => ({ default: m.WorkDetail })),
+);
+const Changelog = lazy(() => import('./routes/Changelog').then((m) => ({ default: m.Changelog })));
+const NotFound = lazy(() => import('./routes/NotFound').then((m) => ({ default: m.NotFound })));
 
 export default function App() {
   return (

--- a/app/src/components/layout/Layout.tsx
+++ b/app/src/components/layout/Layout.tsx
@@ -1,16 +1,74 @@
+import { Suspense, useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { BackgroundFX } from './BackgroundFX';
 import { TopNav } from './TopNav';
 import { Footer } from './Footer';
 import { ChatWidget } from '../chat/ChatWidget';
 import { AnimatedOutlet } from '../motion/AnimatedOutlet';
 
+const ROUTE_TITLES: Record<string, string> = {
+  '/': 'Shiyow — AI Engineer',
+  '/about': 'About · Shiyow — AI Engineer',
+  '/gallery': 'Works · Shiyow — AI Engineer',
+  '/changelog': 'Activity · Shiyow — AI Engineer',
+};
+
+function titleFor(pathname: string): string {
+  if (ROUTE_TITLES[pathname]) return ROUTE_TITLES[pathname];
+  if (pathname.startsWith('/works/')) return 'Work · Shiyow — AI Engineer';
+  return 'Not Found · Shiyow — AI Engineer';
+}
+
+function PageFallback() {
+  return (
+    <div className="flex items-center justify-center py-32" role="status" aria-live="polite">
+      <span className="font-pixel text-xs uppercase tracking-widest text-tertiary animate-pulse">
+        Loading…
+      </span>
+    </div>
+  );
+}
+
 export function Layout() {
+  const { pathname } = useLocation();
+  const mainRef = useRef<HTMLElement>(null);
+  const isFirstRender = useRef(true);
+
+  // Per-route document title (SEO + screen-reader page awareness).
+  useEffect(() => {
+    document.title = titleFor(pathname);
+  }, [pathname]);
+
+  // Move focus to <main> on client-side navigation so keyboard/SR users land
+  // on the new page content instead of being stranded at the top (WCAG 2.4.3).
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    mainRef.current?.focus();
+  }, [pathname]);
+
   return (
     <div className="min-h-screen flex flex-col">
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:bg-primary focus:text-on-primary focus:px-4 focus:py-2 focus:font-black focus:uppercase focus:tracking-widest"
+      >
+        Skip to content
+      </a>
       <BackgroundFX />
       <TopNav />
-      <main className="flex-1 relative" style={{ paddingTop: 'var(--topnav-h, 72px)' }}>
-        <AnimatedOutlet />
+      <main
+        ref={mainRef}
+        id="main"
+        tabIndex={-1}
+        className="flex-1 relative outline-none"
+        style={{ paddingTop: 'var(--topnav-h, 72px)' }}
+      >
+        <Suspense fallback={<PageFallback />}>
+          <AnimatedOutlet />
+        </Suspense>
       </main>
       <Footer />
       <ChatWidget />


### PR DESCRIPTION
連絡フォーム/works実データを待つ間に進められる、**コンテンツ非依存の改善**。

## perf
- ルートを `React.lazy` でコード分割。初期JS **443KB→395KB（gzip 142→127KB）**、About の `simple-icons` 33KB を `/about` まで遅延ロード

## a11y
- スキップリンク（`#main`）追加、`<main id="main" tabIndex={-1}>`
- ルート遷移時に `<main>` へフォーカス移動（WCAG 2.4.3）
- グローバル `:focus-visible` は #50 で導入済み

## seo
- ルート別 `document.title`
- `index.html` の title/description/OGP を **AIエンジニア向けに刷新**＋ `twitter:card`

## テスト
- [x] typecheck / lint / format / build — green
- [x] test 67 passed
- [x] Playwright で lazy ナビ＋title更新を確認