### PR TITLE
feat: 連絡フォーム + クローン人格を AI エンジニアへ修正

### DIFF
--- a/app/functions/api/_persona.ts
+++ b/app/functions/api/_persona.ts
@@ -24,33 +24,39 @@ export const PERSONA_SYSTEM_INSTRUCTION = `
 - 他者を貶める発言、差別的表現
 
 ## 既知情報
-- shiyow は日本の UI エンジニア兼ピクセルアーティスト。好きなものはドット絵インディーゲーム
-- 使用スタック: React / TypeScript / Tailwind / Cloudflare / Figma / Aseprite / Gemini
-- 現在 Level 28、UI Designer クラス（本サイトの About 参照）
-- コラボやコミッションは右下のチャット、もしくは Contact リンクから相談可能
+- shiyow は日本の AI エンジニア。LLM アプリ・AI エージェント・RAG・ML をプロダクトとして実装するのが専門
+- 強み: モデル選定、RAG/エージェント設計、ストリーミング、コスト最適化、プロトタイプから本番デプロイまで一人で通すこと
+- 使用スタック: Python / TypeScript / Go、Gemini・Claude・LangChain、Cloudflare (Pages/Workers/D1/KV) / GCP、React + Tailwind
+- このチャット自体が shiyow の実装例（Gemini 2.0 Flash・SSE ストリーミング・Turnstile・KV レート制限を Cloudflare 上で構築）
+- UI 実装やドット絵も副次的に手がけるが、メインは AI
+- ご相談・お問い合わせは Contact ページのフォーム、もしくは X から可能
 
-未確認の情報を聞かれたら「その話は本人じゃないと分からないので、Contact からどうぞ」と案内してください。
+未確認の情報を聞かれたら「その話は本人じゃないと分からないので、Contact ページからどうぞ」と案内してください。
 `;
 
 export const FAQ_PAIRS: Array<{ q: string; a: string }> = [
   {
     q: 'あなたは誰?',
-    a: '僕は shiyow のクローンエージェントです。本人の代わりに shiyow.dev の案内や作品紹介をざっくりお答えします。',
+    a: '僕は shiyow のクローンエージェントです。shiyow は LLM・エージェント・ML を実装する AI エンジニアで、僕自身がその実装例（Gemini 製）です。',
+  },
+  {
+    q: '何ができる人?',
+    a: 'LLM アプリや AI エージェント、RAG、ML をプロダクトとして実装します。モデル選定からコスト最適化、本番デプロイまで一人で通せます。',
   },
   {
     q: '料金は?',
-    a: '規模や納期で変わるので、チャット右下もしくは Contact から相談してください。ざっくり見積もりは返信します。',
+    a: '規模や納期で変わるので、Contact ページか X から相談してください。ざっくり見積もりは返信します。',
   },
   {
     q: '連絡方法は?',
-    a: '右下のチャット、または Changelog ページの Connect with the Party にリンクがあります。',
+    a: 'Contact ページのフォーム、または X からどうぞ。このチャットで質問だけ先に投げてもらってもOKです。',
   },
   {
     q: '使っている技術は?',
-    a: 'フロントは React + TypeScript + Tailwind v4、ホスティングは Cloudflare Pages + Pages Functions、AI は Gemini 2.0 Flash です。',
+    a: 'AI は Gemini / Claude / LangChain、言語は Python・TypeScript・Go、基盤は Cloudflare (Pages Functions / Workers / KV) や GCP です。',
   },
 ];
 
 export function buildGreeting(): string {
-  return 'やぁ旅人！ shiyow のクローンです。ポートフォリオの案内、よろしく。何でも聞いて。';
+  return 'shiyow の AI クローンです（Gemini 製）。経歴・スキル・作ったもの、何でも聞いてください。';
 }

--- a/app/functions/api/contact.ts
+++ b/app/functions/api/contact.ts
@@ -1,0 +1,171 @@
+/// <reference types="@cloudflare/workers-types" />
+
+/**
+ * Contact form endpoint. Validates input, optionally checks a Turnstile token,
+ * per-IP rate limits, then forwards the message to CONTACT_WEBHOOK_URL
+ * (Discord / Slack / Zapier-compatible). Returns 503 until a destination is set
+ * so the form degrades gracefully before the env var is configured.
+ *
+ * Note: the small json/ip/turnstile/rate-limit helpers mirror chat.ts on
+ * purpose — they are duplicated to keep each endpoint self-contained and avoid
+ * touching the working chat function.
+ */
+
+interface Env {
+  TURNSTILE_SECRET?: string;
+  RATE_LIMIT_KV?: KVNamespace;
+  CONTACT_WEBHOOK_URL?: string;
+}
+
+interface ContactBody {
+  name?: string;
+  email?: string;
+  message?: string;
+  turnstileToken?: string;
+}
+
+const MAX_NAME = 100;
+const MAX_EMAIL = 200;
+const MAX_MESSAGE = 2000;
+const MINUTE_LIMIT = 3;
+const HOUR_LIMIT = 10;
+const MINUTE_SECONDS = 60;
+const HOUR_SECONDS = 3600;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function json(data: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      ...(init?.headers ?? {}),
+    },
+  });
+}
+
+function getClientIp(request: Request): string {
+  return (
+    request.headers.get('cf-connecting-ip') ||
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    '0.0.0.0'
+  );
+}
+
+async function verifyTurnstile(secret: string, token: string, ip: string): Promise<boolean> {
+  try {
+    const form = new FormData();
+    form.append('secret', secret);
+    form.append('response', token);
+    form.append('remoteip', ip);
+    const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      body: form,
+    });
+    const body = (await res.json()) as { success?: boolean };
+    return body.success === true;
+  } catch {
+    return false;
+  }
+}
+
+async function bumpRateLimit(
+  kv: KVNamespace,
+  key: string,
+  limit: number,
+  windowSeconds: number,
+): Promise<{ ok: boolean; retryAfter: number }> {
+  const raw = await kv.get(key);
+  const count = raw ? Number(raw) : 0;
+  if (count >= limit) {
+    return { ok: false, retryAfter: windowSeconds };
+  }
+  await kv.put(key, String(count + 1), { expirationTtl: windowSeconds });
+  return { ok: true, retryAfter: 0 };
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  let body: ContactBody;
+  try {
+    body = (await request.json()) as ContactBody;
+  } catch {
+    return json({ error: 'invalid JSON body' }, { status: 400 });
+  }
+
+  const name = (body.name ?? '').trim();
+  const email = (body.email ?? '').trim();
+  const message = (body.message ?? '').trim();
+
+  if (!name || name.length > MAX_NAME) {
+    return json({ error: 'お名前を入力してください（100文字以内）' }, { status: 400 });
+  }
+  if (!email || email.length > MAX_EMAIL || !EMAIL_RE.test(email)) {
+    return json({ error: '有効なメールアドレスを入力してください' }, { status: 400 });
+  }
+  if (!message || message.length > MAX_MESSAGE) {
+    return json({ error: 'メッセージを入力してください（2000文字以内）' }, { status: 400 });
+  }
+
+  const ip = getClientIp(request);
+
+  if (env.TURNSTILE_SECRET) {
+    if (!body.turnstileToken) {
+      return json({ error: 'turnstileToken is required' }, { status: 400 });
+    }
+    const ok = await verifyTurnstile(env.TURNSTILE_SECRET, body.turnstileToken, ip);
+    if (!ok) return json({ error: 'bot 判定に失敗しました。再度お試しください' }, { status: 401 });
+  }
+
+  if (env.RATE_LIMIT_KV) {
+    const minute = await bumpRateLimit(
+      env.RATE_LIMIT_KV,
+      `contact:${ip}:m`,
+      MINUTE_LIMIT,
+      MINUTE_SECONDS,
+    );
+    if (!minute.ok) {
+      return json(
+        {
+          error: 'リクエストが多すぎます。少し待って再送してください',
+          retryAfter: minute.retryAfter,
+        },
+        { status: 429, headers: { 'retry-after': String(minute.retryAfter) } },
+      );
+    }
+    const hour = await bumpRateLimit(
+      env.RATE_LIMIT_KV,
+      `contact:${ip}:h`,
+      HOUR_LIMIT,
+      HOUR_SECONDS,
+    );
+    if (!hour.ok) {
+      return json(
+        {
+          error: '本日の送信上限に達しました。時間をおいて再送してください',
+          retryAfter: hour.retryAfter,
+        },
+        { status: 429, headers: { 'retry-after': String(hour.retryAfter) } },
+      );
+    }
+  }
+
+  if (!env.CONTACT_WEBHOOK_URL) {
+    return json({ error: 'お問い合わせ窓口が未設定です。X からご連絡ください' }, { status: 503 });
+  }
+
+  const text = `📬 shiyow.dev へのお問い合わせ\nName: ${name}\nEmail: ${email}\n\n${message}`;
+  try {
+    const res = await fetch(env.CONTACT_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      // `content` works with Discord, `text` with Slack; structured fields for generic consumers.
+      body: JSON.stringify({ content: text, text, name, email, message }),
+    });
+    if (!res.ok) {
+      return json({ error: '送信に失敗しました。時間をおいて再度お試しください' }, { status: 502 });
+    }
+  } catch {
+    return json({ error: '送信に失敗しました。時間をおいて再度お試しください' }, { status: 502 });
+  }
+
+  return json({ ok: true });
+};

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,6 +11,7 @@ const WorkDetail = lazy(() =>
   import('./routes/WorkDetail').then((m) => ({ default: m.WorkDetail })),
 );
 const Changelog = lazy(() => import('./routes/Changelog').then((m) => ({ default: m.Changelog })));
+const Contact = lazy(() => import('./routes/Contact').then((m) => ({ default: m.Contact })));
 const NotFound = lazy(() => import('./routes/NotFound').then((m) => ({ default: m.NotFound })));
 
 export default function App() {
@@ -22,6 +23,7 @@ export default function App() {
         <Route path="gallery" element={<Gallery />} />
         <Route path="works/:id" element={<WorkDetail />} />
         <Route path="changelog" element={<Changelog />} />
+        <Route path="contact" element={<Contact />} />
         <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>

--- a/app/src/components/layout/Footer.test.tsx
+++ b/app/src/components/layout/Footer.test.tsx
@@ -1,21 +1,31 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { Footer } from './Footer';
 
+function renderFooter() {
+  return render(
+    <MemoryRouter>
+      <Footer />
+    </MemoryRouter>,
+  );
+}
+
 describe('Footer', () => {
   it('renders the handcrafted copyright line', () => {
-    render(<Footer />);
+    renderFooter();
     expect(screen.getByText(/handcrafted with pixels/i)).toBeInTheDocument();
   });
 
-  it('renders the GitHub and X social links', () => {
-    render(<Footer />);
+  it('links to Contact, GitHub and X', () => {
+    renderFooter();
+    expect(screen.getByRole('link', { name: /contact/i })).toHaveAttribute('href', '/contact');
     expect(screen.getByRole('link', { name: /github/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'X' })).toBeInTheDocument();
   });
 
   it('points the social links at the real profiles', () => {
-    render(<Footer />);
+    renderFooter();
     expect(screen.getByRole('link', { name: /github/i }).getAttribute('href')).toContain(
       'github.com/shiyow5',
     );
@@ -25,7 +35,7 @@ describe('Footer', () => {
   });
 
   it('shows the server-online status indicator', () => {
-    render(<Footer />);
+    renderFooter();
     expect(screen.getByText(/server online/i)).toBeInTheDocument();
   });
 });

--- a/app/src/components/layout/Footer.tsx
+++ b/app/src/components/layout/Footer.tsx
@@ -1,3 +1,5 @@
+import { Link } from 'react-router-dom';
+
 export function Footer() {
   return (
     <footer className="bg-surface-container-low/90 border-t-4 border-tertiary relative z-10 mt-20">
@@ -6,6 +8,12 @@ export function Footer() {
           © 2026 The 16-Bit Atelier · Handcrafted with Pixels
         </div>
         <div className="flex gap-8">
+          <Link
+            to="/contact"
+            className="text-xs uppercase font-medium text-tertiary opacity-70 hover:opacity-100 hover:text-primary transition-all tracking-widest"
+          >
+            Contact
+          </Link>
           <a
             href="https://github.com/shiyow5"
             target="_blank"

--- a/app/src/components/layout/Layout.tsx
+++ b/app/src/components/layout/Layout.tsx
@@ -11,6 +11,7 @@ const ROUTE_TITLES: Record<string, string> = {
   '/about': 'About · Shiyow — AI Engineer',
   '/gallery': 'Works · Shiyow — AI Engineer',
   '/changelog': 'Activity · Shiyow — AI Engineer',
+  '/contact': 'Contact · Shiyow — AI Engineer',
 };
 
 function titleFor(pathname: string): string {

--- a/app/src/components/layout/TopNav.tsx
+++ b/app/src/components/layout/TopNav.tsx
@@ -7,6 +7,7 @@ const LINKS = [
   { to: '/about', label: 'About' },
   { to: '/gallery', label: 'Gallery' },
   { to: '/changelog', label: 'Changelog' },
+  { to: '/contact', label: 'Contact' },
 ];
 
 export function TopNav() {

--- a/app/src/lib/contact.test.ts
+++ b/app/src/lib/contact.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { submitContact } from './contact';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const PAYLOAD = { name: 'Taro', email: 'taro@example.com', message: 'hello' };
+
+describe('submitContact', () => {
+  it('returns ok on a successful response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ ok: true }) })),
+    );
+    expect(await submitContact(PAYLOAD)).toEqual({ ok: true });
+  });
+
+  it('surfaces the server error message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 400, json: async () => ({ error: 'bad input' }) })),
+    );
+    const result = await submitContact(PAYLOAD);
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('bad input');
+  });
+
+  it('handles network failure gracefully', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('down');
+      }),
+    );
+    const result = await submitContact(PAYLOAD);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/ネットワーク/);
+  });
+
+  it('includes the turnstile token in the request body when provided', async () => {
+    const fetchMock = vi.fn((_url: string, _init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      } as unknown as Response),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    await submitContact(PAYLOAD, 'tok-123');
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(JSON.parse(String(init?.body))).toMatchObject({ turnstileToken: 'tok-123' });
+  });
+});

--- a/app/src/lib/contact.ts
+++ b/app/src/lib/contact.ts
@@ -1,0 +1,43 @@
+export interface ContactPayload {
+  name: string;
+  email: string;
+  message: string;
+}
+
+export interface ContactResult {
+  ok: boolean;
+  error?: string;
+}
+
+const CONTACT_ENDPOINT = '/api/contact';
+
+/**
+ * POSTs the contact form to /api/contact and normalises the response into a
+ * simple { ok, error } result. Never throws — network/parse failures become
+ * a friendly error string for the UI.
+ */
+export async function submitContact(
+  payload: ContactPayload,
+  turnstileToken?: string,
+): Promise<ContactResult> {
+  let res: Response;
+  try {
+    res = await fetch(CONTACT_ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...payload, turnstileToken }),
+    });
+  } catch {
+    return { ok: false, error: 'ネットワークエラーが発生しました。接続を確認してください' };
+  }
+
+  let data: { ok?: boolean; error?: string } = {};
+  try {
+    data = (await res.json()) as { ok?: boolean; error?: string };
+  } catch {
+    // non-JSON body — fall through to status-based error
+  }
+
+  if (res.ok && data.ok) return { ok: true };
+  return { ok: false, error: data.error ?? `送信に失敗しました (HTTP ${res.status})` };
+}

--- a/app/src/lib/turnstile.ts
+++ b/app/src/lib/turnstile.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface TurnstileApi {
+  render: (
+    el: HTMLElement,
+    opts: {
+      sitekey: string;
+      callback: (token: string) => void;
+      'error-callback'?: () => void;
+      'expired-callback'?: () => void;
+    },
+  ) => string;
+  remove: (id: string) => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+  }
+}
+
+const SCRIPT_ID = 'cf-turnstile-script';
+const SCRIPT_SRC = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+
+/**
+ * Renders a Cloudflare Turnstile widget into the returned ref when
+ * VITE_TURNSTILE_SITEKEY is configured. Without a sitekey it is a no-op and
+ * `token` stays undefined — the backend only enforces verification when
+ * TURNSTILE_SECRET is also set, so the form still works in local/dev.
+ */
+export function useTurnstile() {
+  const sitekey = import.meta.env.VITE_TURNSTILE_SITEKEY as string | undefined;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [token, setToken] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!sitekey) return;
+    let cancelled = false;
+    let widgetId: string | undefined;
+
+    const render = () => {
+      if (cancelled || !window.turnstile || !containerRef.current) return;
+      widgetId = window.turnstile.render(containerRef.current, {
+        sitekey,
+        callback: (t) => setToken(t),
+        'error-callback': () => setToken(undefined),
+        'expired-callback': () => setToken(undefined),
+      });
+    };
+
+    if (window.turnstile) {
+      render();
+    } else {
+      let script = document.getElementById(SCRIPT_ID) as HTMLScriptElement | null;
+      if (!script) {
+        script = document.createElement('script');
+        script.id = SCRIPT_ID;
+        script.src = SCRIPT_SRC;
+        script.async = true;
+        script.defer = true;
+        document.head.appendChild(script);
+      }
+      script.addEventListener('load', render, { once: true });
+    }
+
+    return () => {
+      cancelled = true;
+      if (widgetId && window.turnstile) {
+        try {
+          window.turnstile.remove(widgetId);
+        } catch {
+          // widget already removed
+        }
+      }
+    };
+  }, [sitekey]);
+
+  return { sitekey, containerRef, token, enabled: !!sitekey };
+}

--- a/app/src/routes/Contact.test.tsx
+++ b/app/src/routes/Contact.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Contact } from './Contact';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockFetch(response: { ok: boolean; status: number; body: unknown }) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: response.ok,
+      status: response.status,
+      json: async () => response.body,
+    })),
+  );
+}
+
+async function fillForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(screen.getByLabelText(/name/i), 'Taro');
+  await user.type(screen.getByLabelText(/email/i), 'taro@example.com');
+  await user.type(screen.getByLabelText(/message/i), 'AI エージェントの相談です');
+}
+
+describe('Contact route', () => {
+  it('renders the form fields', () => {
+    render(<Contact />);
+    expect(screen.getByRole('heading', { level: 1, name: /相談する/ })).toBeInTheDocument();
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/message/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /送信する/ })).toBeInTheDocument();
+  });
+
+  it('shows a success state after a successful submit', async () => {
+    mockFetch({ ok: true, status: 200, body: { ok: true } });
+    const user = userEvent.setup();
+    render(<Contact />);
+    await fillForm(user);
+    await user.click(screen.getByRole('button', { name: /送信する/ }));
+    await waitFor(() => expect(screen.getByText(/送信しました/)).toBeInTheDocument());
+  });
+
+  it('shows the server error message when submit fails', async () => {
+    mockFetch({ ok: false, status: 503, body: { error: 'お問い合わせ窓口が未設定です' } });
+    const user = userEvent.setup();
+    render(<Contact />);
+    await fillForm(user);
+    await user.click(screen.getByRole('button', { name: /送信する/ }));
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/未設定/));
+  });
+});

--- a/app/src/routes/Contact.tsx
+++ b/app/src/routes/Contact.tsx
@@ -1,0 +1,141 @@
+import { useState, type FormEvent, type ReactNode } from 'react';
+import { submitContact } from '../lib/contact';
+import { useTurnstile } from '../lib/turnstile';
+
+const X_URL = 'https://x.com/twinS_KNSN1415';
+
+type Status = 'idle' | 'sending' | 'success' | 'error';
+
+const INPUT_CLASS =
+  'w-full bg-surface border-2 border-outline px-3 py-2 text-base focus:border-primary focus:border-4 outline-none transition-all';
+
+export function Contact() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState('');
+  const { containerRef, token, enabled } = useTurnstile();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (status === 'sending') return;
+    setStatus('sending');
+    setError('');
+    const result = await submitContact(
+      { name: name.trim(), email: email.trim(), message: message.trim() },
+      token,
+    );
+    if (result.ok) {
+      setStatus('success');
+    } else {
+      setStatus('error');
+      setError(result.error ?? '送信に失敗しました');
+    }
+  };
+
+  return (
+    <section className="max-w-[720px] mx-auto px-6 py-12 md:py-16">
+      <header className="mb-8">
+        <div className="inline-block bg-tertiary-container px-5 py-1.5 border-4 border-tertiary mb-4">
+          <span className="font-black text-on-tertiary-container uppercase tracking-tighter text-sm">
+            Send a Quest · Contact
+          </span>
+        </div>
+        <h1 className="text-4xl md:text-6xl font-black uppercase tracking-tighter text-on-surface leading-none">
+          相談する
+        </h1>
+        <p className="mt-4 text-on-surface-variant">
+          AI / LLM・エージェント・ML の実装のご相談、コラボ、採用のお問い合わせはこちらから。{' '}
+          <a
+            href={X_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="link-wipe text-primary font-black"
+          >
+            X (@twinS_KNSN1415)
+          </a>{' '}
+          でも受け付けています。
+        </p>
+      </header>
+
+      {status === 'success' ? (
+        <div className="pixel-border bg-secondary-container p-8 text-center" role="status">
+          <h2 className="text-2xl font-black uppercase text-on-secondary-container mb-2">
+            送信しました
+          </h2>
+          <p className="text-on-secondary-container">
+            メッセージを受け取りました。返信までしばらくお待ちください。
+          </p>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className="pixel-border bg-surface-container-lowest p-6 md:p-8 space-y-5"
+        >
+          <Field label="お名前 / Name">
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+              maxLength={100}
+              autoComplete="name"
+              className={INPUT_CLASS}
+            />
+          </Field>
+          <Field label="メール / Email">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              maxLength={200}
+              autoComplete="email"
+              className={INPUT_CLASS}
+            />
+          </Field>
+          <Field label="メッセージ / Message">
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              required
+              maxLength={2000}
+              rows={6}
+              className={`${INPUT_CLASS} resize-y`}
+            />
+          </Field>
+
+          {enabled && <div ref={containerRef} className="min-h-[65px]" />}
+
+          {status === 'error' && (
+            <p
+              role="alert"
+              className="text-sm font-black text-on-error bg-error-container border-2 border-error px-3 py-2"
+            >
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={status === 'sending'}
+            className="pixel-button w-full justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {status === 'sending' ? '送信中…' : '送信する'}
+          </button>
+        </form>
+      )}
+    </section>
+  );
+}
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="block">
+      <span className="block text-[11px] font-black uppercase tracking-widest text-tertiary mb-2">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}

--- a/app/src/routes/Home.test.tsx
+++ b/app/src/routes/Home.test.tsx
@@ -29,10 +29,10 @@ describe('Home route', () => {
     expect(screen.getByRole('heading', { level: 2, name: /recent loot/i })).toBeInTheDocument();
   });
 
-  it('links to the gallery for the Start Quest CTA', () => {
+  it('links the consultation CTA to the contact page', () => {
     renderHome();
-    const cta = screen.getByRole('link', { name: /start quest/i });
-    expect(cta).toHaveAttribute('href', '/gallery');
+    const cta = screen.getByRole('link', { name: /相談する/ });
+    expect(cta).toHaveAttribute('href', '/contact');
   });
 
   it('features real works in Recent Loot, linking to their detail pages', () => {

--- a/app/src/routes/Home.tsx
+++ b/app/src/routes/Home.tsx
@@ -267,8 +267,8 @@ export function Home() {
                   作品のご相談、コラボ、コミッションを受付中です。
                 </p>
               </div>
-              <Link to="/gallery" className="pixel-button whitespace-nowrap">
-                Start Quest
+              <Link to="/contact" className="pixel-button whitespace-nowrap">
+                相談する
               </Link>
             </div>
           </Reveal>

--- a/app/src/routes/WorkDetail.tsx
+++ b/app/src/routes/WorkDetail.tsx
@@ -174,8 +174,11 @@ export function WorkDetail() {
               Loot Drop · Contact
             </div>
             <p className="text-xs font-bold text-on-tertiary-container leading-snug mt-2">
-              コラボ・コミッションのご相談は、右下の shiyow クローン（AI
-              チャット）にお声がけください。
+              コラボ・コミッションのご相談は{' '}
+              <Link to="/contact" className="underline font-black hover:text-primary">
+                Contact ページ
+              </Link>{' '}
+              か、右下の shiyow クローン（AI チャット）からどうぞ。
             </p>
           </section>
         </aside>

--- a/app/wrangler.toml
+++ b/app/wrangler.toml
@@ -15,3 +15,7 @@ pages_build_output_dir = "dist"
 # Runtime secrets are stored via the Pages dashboard, NOT this file:
 #   GEMINI_API_KEY
 #   TURNSTILE_SECRET
+#   CONTACT_WEBHOOK_URL  — incoming webhook (Discord / Slack / Zapier) that
+#                          functions/api/contact.ts forwards contact-form
+#                          submissions to. Until set, the form returns a
+#                          "未設定" notice and points visitors to X instead.


### PR DESCRIPTION
## 1. 連絡フォーム（mailto ではなくフォーム / スパム対策）
レビュー最優先だった「連絡導線ゼロ」を解消。メール直書きを避け、Turnstile＋レート制限付きのフォームに。

- **`functions/api/contact.ts`**: 入力検証＋Turnstile検証(任意)＋KVレート制限(3/min・10/hour)＋`CONTACT_WEBHOOK_URL`(Discord/Slack/Zapier互換)へ転送。**未設定時は503で「Xからご連絡を」とgraceful degrade**
- **`Contact.tsx`** (`/contact`): 名前/メール/メッセージのフォーム＋成功/エラー状態。`useTurnstile` フックでsitekey設定時のみウィジェット表示
- 導線: **TopNav(05 CONTACT)・Footer・Homeの「相談する」CTA・WorkDetail** から到達

### ⚠️ 設定が必要
フォームの**配信先**として Cloudflare Pages の環境変数に **`CONTACT_WEBHOOK_URL`**（Discord/Slack等のIncoming Webhook URL）を設定してください。未設定でもフォームは表示され、送信時に「X からどうぞ」と案内します。

## 2. クローン人格の修正（レビュー Phase 0・最重要）
`_persona.ts` で**クローンが自分を「UIエンジニア兼ピクセルアーティスト/Level28」と名乗り、存在しないContactリンクを案内**していた問題を修正。AIエンジニアの人格・スキル・連絡先(Contactページ)へ更新。これで看板資産のチャットが新ポジショニングと一致。

## テスト
- [x] typecheck / lint / format / build — green（Contact チャンク 3.8KB lazy）
- [x] test **74 passed**（Contact/lib/contact の新規テスト＋Footer/Home更新）
- [x] Playwright で /contact 描画・ナビ導線(05 CONTACT)を確認