### PR TITLE
feat(data): Notion の就活データを反映（実プロジェクト/スキル/活動）

### DIFF
--- a/app/src/components/editorial/EditorialSite.tsx
+++ b/app/src/components/editorial/EditorialSite.tsx
@@ -385,6 +385,14 @@ function ContactSection({ askClone }: { askClone: () => void }) {
           >
             GitHub / shiyow5 ↗
           </a>
+          <a
+            href="https://www.kaggle.com/sshow14"
+            target="_blank"
+            rel="noreferrer"
+            className="block hover:text-primary"
+          >
+            Kaggle / sshow14 ↗
+          </a>
         </aside>
       </div>
     </motion.section>

--- a/app/src/data/activity.json
+++ b/app/src/data/activity.json
@@ -19,7 +19,7 @@
   },
   {
     "id": "fastbear-release",
-    "date": "2026-05-01",
+    "date": "2025-12-01",
     "title": "FASTBEAR を公開（アオタケ採択）",
     "category": "release",
     "summary": "クマ出没情報を自動収集・構造化する AI エージェントを開発し公開。",

--- a/app/src/data/activity.json
+++ b/app/src/data/activity.json
@@ -1,74 +1,67 @@
 [
   {
-    "id": "portfolio-v0-2",
-    "date": "2026-04-22",
-    "title": "shiyow.dev v0.2.0 を公開",
-    "category": "release",
-    "summary": "16-Bit Atélier デザイン / 部屋を歩き回るキャラ / ハンバーガーナビ / 全ページのスクロールリビールを実装。",
-    "tags": ["portfolio", "web"],
-    "links": [{ "label": "Source", "url": "https://github.com/shiyow5/portfolio-web" }]
-  },
-  {
-    "id": "post-pixel-tokens",
-    "date": "2026-03-18",
-    "title": "Tailwind v4 @theme でドット絵トークンを組む",
-    "category": "post",
-    "summary": "4px 刻みボーダー・ドット絵アイコンのレンダリング指針・BackgroundFX のレイヤ構成まで解説。",
-    "tags": ["tailwind", "pixel-art"],
-    "links": []
-  },
-  {
-    "id": "lt-pixel-webdev",
-    "date": "2025-11-02",
-    "title": "LT: 個人開発でも続くピクセルアート UI 運用",
-    "category": "talk",
-    "summary": "ローカル勉強会 15 分枠。デザインガイドライン / Aseprite パイプライン / Figma との往復フロー。",
-    "tags": ["talk", "ui"],
-    "links": []
-  },
-  {
-    "id": "neon-circuit-v2",
-    "date": "2025-09-12",
-    "title": "Neon Circuit v2.1.0 を OSS リリース",
-    "category": "release",
-    "summary": "サイバーパンク UI キット。140 コンポーネント・3 テーマ・Figma ソースを含む。",
-    "tags": ["ui-kit", "oss"],
-    "links": [{ "label": "GitHub", "url": "https://github.com/shiyow5/neon-circuit" }]
-  },
-  {
-    "id": "feature-x-weekly",
-    "date": "2025-06-04",
-    "title": "週刊ピクセル系ニュースレターに掲載",
-    "category": "award",
-    "summary": "Asset Pack 01 が海外のインディー向けニュースレターで紹介された。",
-    "tags": ["recognition"],
-    "links": []
-  },
-  {
-    "id": "asset-pack-01",
-    "date": "2024-11-20",
-    "title": "Asset Pack 01 リリース",
-    "category": "release",
-    "summary": "32x32 CC0 ファンタジーアイコン 120 種。武器・ポーション・食料・UI パーツを網羅。",
-    "tags": ["cc0", "pixel-art"],
-    "links": []
-  },
-  {
-    "id": "switch-to-cloudflare",
-    "date": "2024-06-02",
-    "title": "インフラを Cloudflare に統一",
-    "category": "project",
-    "summary": "個人プロジェクト全体を Pages / Workers / D1 に寄せ、egress ゼロ構成へ移行。",
-    "tags": ["infra"],
-    "links": []
-  },
-  {
-    "id": "career-start",
-    "date": "2024-01-15",
-    "title": "個人開発を本格化 — AI 実装に注力開始",
+    "id": "matsuo-intern",
+    "date": "2026-06-01",
+    "title": "東京大学 松尾研究室 インターン開始",
     "category": "job",
-    "summary": "LLM・エージェント・ML を中心に、プロダクトとして動かす個人開発に注力し始める。",
-    "tags": ["career", "ai"],
+    "summary": "情報の構造化に関するリサーチに従事。",
+    "tags": ["internship", "research"],
+    "links": []
+  },
+  {
+    "id": "grad-school",
+    "date": "2026-04-01",
+    "title": "大学院進学・LLM 効率化研究を開始",
+    "category": "project",
+    "summary": "会津大学大学院 Computer Science 専攻へ。長文脈 LLM 推論の KV キャッシュ効率化を研究。",
+    "tags": ["llm", "research"],
+    "links": []
+  },
+  {
+    "id": "fastbear-release",
+    "date": "2026-05-01",
+    "title": "FASTBEAR を公開（アオタケ採択）",
+    "category": "release",
+    "summary": "クマ出没情報を自動収集・構造化する AI エージェントを開発し公開。",
+    "tags": ["ai-agent", "oss"],
+    "links": [{ "label": "Demo", "url": "https://fastbear.aisometry.com/" }]
+  },
+  {
+    "id": "astralyx-award",
+    "date": "2026-03-01",
+    "title": "GDGoC Japan Hackathon 2026 優秀賞（Astralyx）",
+    "category": "award",
+    "summary": "視聴履歴を 3D 可視化し AI が分析するアプリで優秀賞。AI パイプライン・3D 可視化を主担当。",
+    "tags": ["hackathon", "award"],
+    "links": []
+  },
+  {
+    "id": "onplanetz-intern",
+    "date": "2024-12-01",
+    "title": "Onplanetz 株式会社 インターン開始",
+    "category": "job",
+    "summary": "ドキュメント構造化・RAG システムの精度改善に従事（〜2026.6）。",
+    "tags": ["internship", "rag"],
+    "links": []
+  },
+  {
+    "id": "pokemon-cry-release",
+    "date": "2025-08-01",
+    "title": "Pokémon Cry Stats Predictor を公開",
+    "category": "release",
+    "summary": "鳴き声から種族値を予測する ML プロジェクトを GitHub に公開。",
+    "tags": ["ml", "oss"],
+    "links": [
+      { "label": "GitHub", "url": "https://github.com/shiyow5/pokemon-cry-stats-predictor" }
+    ]
+  },
+  {
+    "id": "thesis",
+    "date": "2025-02-01",
+    "title": "卒業研究（TextWorld 強化学習）を完了",
+    "category": "project",
+    "summary": "RL エージェントを LSTM / Transformer / GPT-2 で比較し、知見を論文化。",
+    "tags": ["rl", "research"],
     "links": []
   }
 ]

--- a/app/src/data/profile.json
+++ b/app/src/data/profile.json
@@ -1,72 +1,51 @@
 {
   "name": "Shiyow",
-  "classTitle": "AI Engineer / LLM・Agent Developer",
-  "level": 28,
-  "xp": 12450,
-  "xpNext": 15000,
-  "location": "Digital Highlands, JP",
-  "bioQuote": "LLM とエージェントで動くプロダクトを作る AI エンジニア。モデル選定・RAG・エージェント設計の実装から、手触りの良い UI まで一気通貫で仕上げるのが好きです。",
-  "stats": [
-    { "label": "HP", "value": 92, "max": 100, "color": "secondary" },
-    { "label": "Focus", "value": 74, "max": 100, "color": "primary" },
-    { "label": "Creativity", "value": 88, "max": 100, "color": "tertiary" }
-  ],
+  "classTitle": "AI Engineer / ML・LLM",
+  "location": "Aizu, Japan",
   "techStack": [
     {
       "id": "ai",
       "label": "AI & Agents",
-      "icon": "smart_toy",
-      "items": ["Gemini 2.0 Flash", "Claude", "LangChain", "RAG", "Vectorize (Workers AI)"]
+      "items": [
+        "Gemini / Vertex AI",
+        "LangGraph / LangChain",
+        "RAG (pgvector)",
+        "Function Calling",
+        "強化学習 (PPO)",
+        "LLM 効率化 (KV Cache)"
+      ]
+    },
+    {
+      "id": "ml",
+      "label": "Machine Learning",
+      "items": ["PyTorch", "TensorFlow", "scikit-learn", "Hugging Face", "XGBoost", "librosa"]
     },
     {
       "id": "languages",
       "label": "Languages",
-      "icon": "code",
-      "items": ["Python", "TypeScript", "JavaScript", "Go", "SQL"]
+      "items": ["Python", "TypeScript", "Go", "C / C++", "Java"]
     },
     {
-      "id": "frameworks",
-      "label": "Frameworks & Runtime",
-      "icon": "deployed_code",
-      "items": ["React 19", "Vite 8", "Tailwind CSS v4", "Motion", "Node.js"]
+      "id": "web",
+      "label": "Web",
+      "items": ["Next.js", "React", "Three.js (R3F)", "Hono", "Streamlit", "Tailwind CSS"]
     },
     {
       "id": "cloud",
       "label": "Cloud & Infra",
-      "icon": "cloud",
-      "items": ["Cloudflare Pages", "Workers", "D1", "R2", "KV", "GCP", "Vercel"]
+      "items": [
+        "Google Cloud (Run / Vertex AI)",
+        "Azure Functions",
+        "Cloudflare",
+        "Supabase",
+        "Docker",
+        "GitHub Actions"
+      ]
     },
     {
       "id": "tools",
-      "label": "Tools",
-      "icon": "build",
-      "items": ["VS Code", "Git", "gh CLI", "tmux", "Wrangler"]
-    },
-    {
-      "id": "design",
-      "label": "Design & Pixel Art",
-      "icon": "brush",
-      "items": ["Figma", "FigJam", "Aseprite", "Photoshop"]
-    },
-    {
-      "id": "gamedev",
-      "label": "Game Dev",
-      "icon": "sports_esports",
-      "items": ["Unity", "Godot"]
+      "label": "Tools & More",
+      "items": ["Git / GitHub", "Pygame", "discord.js", "LINE Bot", "Drizzle ORM"]
     }
-  ],
-  "perks": [
-    "Passive: 自分のクローン AI をサイトに住まわせている",
-    "Passive: モデル選定とコスト最適化が習慣",
-    "Active: プロトタイプから本番デプロイまで一人で通す"
-  ],
-  "history": [
-    {
-      "year": 2026,
-      "title": "shiyow.dev を公開",
-      "detail": "Cloudflare Pages + Gemini クローンエージェント"
-    },
-    { "year": 2025, "title": "Neon Circuit リリース", "detail": "ネオン UI キットを OSS 公開" },
-    { "year": 2024, "title": "Asset Pack 01 リリース", "detail": "CC0 ファンタジーアイコン 120 種" }
   ]
 }

--- a/app/src/data/works.json
+++ b/app/src/data/works.json
@@ -1,84 +1,83 @@
 [
   {
-    "id": "aether-drift",
-    "title": "Aether Drift",
-    "category": "game",
-    "tagline": "手描き 16-bit タイルで組むプロシージャル雲上アクション。",
-    "description": "カスタムシェーダと独自タイルセットで実装したプロシージャル・プラットフォーマー。HSL ベースの時間帯サイクルで空の色が変化します。",
-    "cover": "/rooms/simple_room.png",
-    "gallery": ["/rooms/simple_room.png"],
-    "tags": ["Platformer", "Pixel Art", "Custom Shader"],
-    "tech": ["TypeScript", "WebGL", "Aseprite"],
-    "version": "1.0.4",
-    "status": "new",
+    "id": "astralyx",
+    "title": "Astralyx",
+    "tagline": "YouTube 視聴履歴を 3D 宇宙に可視化し、AI が興味関心を分析・対話するアプリ。HDBSCAN を自作し embedding→クラスタリングの AI パイプラインと 3D 可視化を主担当。1 週間で 500+ コミット、デプロイ・ユーザーテストまで実施。",
+    "tech": ["Next.js", "Three.js (R3F)", "Go", "Gemini", "Vertex AI"],
+    "status": "ハッカソン優秀賞 · Team",
     "year": 2026,
-    "links": {
-      "github": "https://github.com/shiyow5/aether-drift"
-    }
+    "links": {}
   },
   {
-    "id": "neon-circuit",
-    "title": "Neon Circuit",
-    "category": "uiux",
-    "tagline": "サイバーパンク UI キット＋アイソメ環境。",
-    "description": "ネオン基板から着想した UI コンポーネント集。ダークモード固定、発光はすべて 2px 以内のストロークで表現。",
-    "cover": "/rooms/simple_room.png",
-    "gallery": ["/rooms/simple_room.png"],
-    "tags": ["UI Toolkit", "Isometric", "Design System"],
-    "tech": ["Figma", "Framer Motion", "Tailwind"],
-    "version": "2.1.0",
-    "status": "stable",
+    "id": "llm-kv-cache",
+    "title": "長文脈 LLM 推論の効率化（修士研究）",
+    "tagline": "自己検証付き階層的 KV キャッシュ近似で、長文脈 LLM 推論を品質を保ちつつ軽く・速く。直近は詳細・古い文脈は要約で記憶し、近似が信頼できるかを AI 自身が推論中に検証、危険時は丁寧な計算へ fallback。",
+    "tech": ["Python", "PyTorch", "Hugging Face", "LLM", "KV Cache"],
+    "status": "研究 · 進行中",
+    "year": 2026,
+    "links": {}
+  },
+  {
+    "id": "fastbear",
+    "title": "FASTBEAR",
+    "tagline": "クマ出没情報を AI が自動収集・構造化し、地図と SNS へ届ける社会課題解決サービス。ニュースの LLM 構造化抽出＋LangGraph によるファクトチェックを担当。27 都道府県を GitHub Actions で定期収集。",
+    "tech": ["Python", "Gemini", "LangGraph", "Supabase", "Next.js", "Leaflet"],
+    "status": "公開中 · Team（アオタケ採択）",
+    "year": 2026,
+    "links": { "demo": "https://fastbear.aisometry.com/" }
+  },
+  {
+    "id": "dm-ai",
+    "title": "DM-AI",
+    "tagline": "デュエル・マスターズ Q&A ボット。RAG＋構造化 DB＋Function Calling のハイブリッドで、ルール検索（条文番号付き）・デッキ評価・環境分析を統合。",
+    "tech": ["Next.js", "Hono", "Gemini", "Supabase (pgvector)", "Drizzle"],
+    "status": "公開 · 個人",
+    "year": 2026,
+    "links": { "github": "https://github.com/shiyow5/DuelMasters-AI" }
+  },
+  {
+    "id": "pokemon-cry",
+    "title": "Pokémon Cry Stats Predictor",
+    "tagline": "鳴き声から 6 種のステータスを予測する ML プロジェクト。59 次元の音響特徴量（MFCC / Chroma / Tonnetz 等）を抽出し、Random Forest / XGBoost / NN を 5-Fold CV で比較。Streamlit ダッシュボードも実装。",
+    "tech": ["Python", "TensorFlow", "scikit-learn", "XGBoost", "librosa"],
+    "status": "公開 · 個人",
     "year": 2025,
-    "links": {
-      "github": "https://github.com/shiyow5/neon-circuit"
-    }
+    "links": { "github": "https://github.com/shiyow5/pokemon-cry-stats-predictor" }
   },
   {
-    "id": "loot-logic",
-    "title": "Loot Logic",
-    "category": "prototype",
-    "tagline": "RPG のインベントリ管理システム試作。",
-    "description": "グリッド配置・スタック数・重量制約を 1 ファイルで検証できる最小プロトタイプ。テトリス風の自動パッキング機能を検証中。",
-    "cover": "/rooms/simple_room.png",
-    "gallery": ["/rooms/simple_room.png"],
-    "tags": ["Prototype", "State Machine"],
-    "tech": ["React", "Zustand"],
-    "version": "alpha",
-    "status": "wip",
+    "id": "ptcg-ai",
+    "title": "PTCG-AI Battle Challenge",
+    "tagline": "ポケモンカード AI エージェント（Kaggle「Pokemon TCG AI Battle」）。戦略決定ロジックの実装・学習・評価を担当し、Docker で再現可能な提出パイプラインとエージェント同士の対戦テストを整備。",
+    "tech": ["Python", "Docker", "Kaggle"],
+    "status": "コンペ · Team",
     "year": 2026,
+    "links": { "demo": "https://www.kaggle.com/sshow14" }
+  },
+  {
+    "id": "oekaki-battler",
+    "title": "お絵描きバトラー",
+    "tagline": "手描きキャラを Gemini が解析し、自動生成したステータスで対戦するゲーム。学園祭の新企画として企画立案〜アプリ開発を個人で担当。LINE Bot から画像登録、ポーリング最適化で API 呼び出しを大幅削減。",
+    "tech": ["Python", "Gemini", "Pygame", "LINE Bot"],
+    "status": "学園祭企画 · 個人",
+    "year": 2025,
     "links": {}
   },
   {
-    "id": "asset-pack-01",
-    "title": "Asset Pack 01",
-    "category": "art",
-    "tagline": "32x32 の CC0 ファンタジーアイコン集。",
-    "description": "武器・ポーション・食料など 120 種の 32x32 アイコン。インディー開発者向けに CC0 で公開。",
-    "cover": "/rooms/simple_room.png",
-    "gallery": ["/rooms/simple_room.png"],
-    "tags": ["2D Art", "CC0", "Icons"],
-    "tech": ["Aseprite", "Photoshop"],
-    "version": "1.2",
-    "status": "stable",
-    "year": 2024,
+    "id": "textworld-rl",
+    "title": "TextWorld 強化学習エージェント（卒業研究）",
+    "tagline": "「言語指示→実行コマンド」を学ぶ RL エージェントを LSTM / Transformer / GPT-2 で比較。特定ドメインでは汎用 LLM の微調整より小型 Transformer が安定・高成功率と示した。",
+    "tech": ["Python", "PyTorch", "PPO", "TextWorld"],
+    "status": "卒業研究 · 個人",
+    "year": 2025,
     "links": {}
   },
   {
-    "id": "cozy-workshop",
-    "title": "Cozy Workshop",
-    "category": "web",
-    "tagline": "ピクセル職人のための Web 制作実験場。",
-    "description": "本ポートフォリオそのもの。Cloudflare Pages + Pages Functions + Gemini で将来のクローンエージェントを動かす基盤。",
-    "cover": "/rooms/simple_room.png",
-    "gallery": ["/rooms/simple_room.png"],
-    "tags": ["Web", "React", "Cloudflare"],
-    "tech": ["Vite", "React 19", "Tailwind v4", "Cloudflare Pages", "Gemini"],
-    "version": "0.1.0",
-    "status": "wip",
+    "id": "shiyow-dev",
+    "title": "shiyow.dev",
+    "tagline": "このポートフォリオ。editorial / terminal の 2 モードと、Gemini 製の自作クローン AI チャット（SSE ストリーミング・Turnstile・KV レート制限）を Cloudflare 上で実装。",
+    "tech": ["React 19", "Vite", "Tailwind v4", "Cloudflare Pages", "Gemini"],
+    "status": "公開 · 個人",
     "year": 2026,
-    "links": {
-      "demo": "https://shiyow.dev",
-      "github": "https://github.com/shiyow5/portfolio-web"
-    }
+    "links": { "github": "https://github.com/shiyow5/portfolio-web" }
   }
 ]

--- a/app/src/data/works.json
+++ b/app/src/data/works.json
@@ -23,7 +23,7 @@
     "tagline": "クマ出没情報を AI が自動収集・構造化し、地図と SNS へ届ける社会課題解決サービス。ニュースの LLM 構造化抽出＋LangGraph によるファクトチェックを担当。27 都道府県を GitHub Actions で定期収集。",
     "tech": ["Python", "Gemini", "LangGraph", "Supabase", "Next.js", "Leaflet"],
     "status": "公開中 · Team（アオタケ採択）",
-    "year": 2026,
+    "year": 2025,
     "links": { "demo": "https://fastbear.aisometry.com/" }
   },
   {

--- a/app/src/lib/profile.ts
+++ b/app/src/lib/profile.ts
@@ -1,39 +1,16 @@
 import raw from '../data/profile.json';
 
-export type StatColor = 'primary' | 'secondary' | 'tertiary';
-
-export interface Stat {
-  label: string;
-  value: number;
-  max: number;
-  color: StatColor;
-}
-
 export interface TechStackGroup {
   id: string;
   label: string;
-  icon: string;
   items: string[];
-}
-
-export interface HistoryEntry {
-  year: number;
-  title: string;
-  detail: string;
 }
 
 export interface Profile {
   name: string;
   classTitle: string;
-  level: number;
-  xp: number;
-  xpNext: number;
   location: string;
-  bioQuote: string;
-  stats: Stat[];
   techStack: TechStackGroup[];
-  perks: string[];
-  history: HistoryEntry[];
 }
 
 export const PROFILE: Profile = raw as Profile;

--- a/app/src/lib/works.test.ts
+++ b/app/src/lib/works.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { CATEGORY_LABEL, WORKS, filterByCategory, findWork, listCategories } from './works';
+import { WORKS } from './works';
 
 describe('WORKS catalogue', () => {
   it('exposes a non-empty list', () => {
@@ -10,10 +10,12 @@ describe('WORKS catalogue', () => {
     for (const work of WORKS) {
       expect(work.id).toBeTruthy();
       expect(work.title).toBeTruthy();
-      expect(['game', 'uiux', 'web', 'art', 'prototype']).toContain(work.category);
-      expect(['new', 'stable', 'wip']).toContain(work.status);
+      expect(work.tagline).toBeTruthy();
+      expect(Array.isArray(work.tech)).toBe(true);
+      expect(work.tech.length).toBeGreaterThan(0);
+      expect(typeof work.status).toBe('string');
       expect(typeof work.year).toBe('number');
-      expect(Array.isArray(work.tags)).toBe(true);
+      expect(typeof work.links).toBe('object');
     }
   });
 
@@ -21,60 +23,15 @@ describe('WORKS catalogue', () => {
     const ids = WORKS.map((work) => work.id);
     expect(new Set(ids).size).toBe(ids.length);
   });
-});
 
-describe('findWork', () => {
-  it('returns undefined for an undefined id', () => {
-    expect(findWork(undefined)).toBeUndefined();
-  });
-
-  it('returns undefined for an unknown id', () => {
-    expect(findWork('does-not-exist')).toBeUndefined();
-  });
-
-  it('returns the matching work for a known id', () => {
-    const first = WORKS[0];
-    expect(findWork(first.id)).toEqual(first);
-  });
-});
-
-describe('filterByCategory', () => {
-  it('returns the full catalogue for "all"', () => {
-    expect(filterByCategory('all')).toEqual(WORKS);
-  });
-
-  it('returns only works in the requested category', () => {
-    const category = WORKS[0].category;
-    const filtered = filterByCategory(category);
-    expect(filtered.length).toBeGreaterThan(0);
-    expect(filtered.every((work) => work.category === category)).toBe(true);
-  });
-});
-
-describe('listCategories', () => {
-  it('always starts with "all"', () => {
-    expect(listCategories()[0]).toBe('all');
-  });
-
-  it('includes every category present in the catalogue, without duplicates', () => {
-    const categories = listCategories();
-    expect(new Set(categories).size).toBe(categories.length);
+  it('only exposes absolute http(s) links (no placeholders)', () => {
     for (const work of WORKS) {
-      expect(categories).toContain(work.category);
-    }
-  });
-
-  it('sorts the categories after "all" alphabetically', () => {
-    const [, ...rest] = listCategories();
-    expect(rest).toEqual([...rest].sort());
-  });
-});
-
-describe('CATEGORY_LABEL', () => {
-  it('has a label for "all" and every category in use', () => {
-    expect(CATEGORY_LABEL.all).toBeTruthy();
-    for (const work of WORKS) {
-      expect(CATEGORY_LABEL[work.category]).toBeTruthy();
+      for (const url of Object.values(work.links)) {
+        if (url) {
+          expect(url).toMatch(/^https?:\/\//);
+          expect(url).not.toContain('example.com');
+        }
+      }
     }
   });
 });

--- a/app/src/lib/works.ts
+++ b/app/src/lib/works.ts
@@ -1,54 +1,20 @@
 import raw from '../data/works.json';
 
-export type WorkCategory = 'game' | 'uiux' | 'web' | 'art' | 'prototype';
-
-export type WorkStatus = 'new' | 'stable' | 'wip';
-
 export interface WorkLinks {
-  play?: string;
-  demo?: string;
   github?: string;
+  demo?: string;
+  play?: string;
 }
 
 export interface Work {
   id: string;
   title: string;
-  category: WorkCategory;
   tagline: string;
-  description: string;
-  cover: string;
-  gallery: string[];
-  tags: string[];
   tech: string[];
-  version: string;
-  status: WorkStatus;
+  /** Short free-form status label, e.g. "優秀賞 · Team" / "公開 · 個人". */
+  status: string;
   year: number;
   links: WorkLinks;
 }
 
 export const WORKS: Work[] = raw as Work[];
-
-export const CATEGORY_LABEL: Record<WorkCategory | 'all', string> = {
-  all: 'All Quests',
-  game: 'Games',
-  uiux: 'UI / UX',
-  web: 'Web Crafts',
-  art: '2D Art',
-  prototype: 'Prototypes',
-};
-
-export function findWork(id: string | undefined): Work | undefined {
-  if (!id) return undefined;
-  return WORKS.find((work) => work.id === id);
-}
-
-export function filterByCategory(category: WorkCategory | 'all'): Work[] {
-  if (category === 'all') return WORKS;
-  return WORKS.filter((work) => work.category === category);
-}
-
-export function listCategories(): Array<WorkCategory | 'all'> {
-  const set = new Set<WorkCategory>();
-  for (const work of WORKS) set.add(work.category);
-  return ['all', ...Array.from(set).sort()];
-}


### PR DESCRIPTION
Notion の「就活」DB から実データを取得し、プレースホルダを全面差し替え。

## works.json（実プロジェクト9件）
Astralyx（GDGoC Japan Hackathon 2026 **優秀賞**）/ 長文脈 LLM 推論の効率化（修士研究・KVキャッシュ）/ FASTBEAR（アオタケ採択・公開中）/ DM-AI（RAG）/ Pokémon Cry Stats Predictor / PTCG-AI（Kaggle）/ お絵描きバトラー / TextWorld 強化学習（卒研）/ shiyow.dev。実リンク（公開リポ・デモ・Kaggle）付き。

## profile.json
肩書き **AI Engineer / ML・LLM**、location **Aizu, Japan**、techStack を実スキル（AI & Agents / Machine Learning / Languages / Web / Cloud & Infra / Tools）へ。

## activity.json
松尾研インターン / 大学院・LLM 研究 / FASTBEAR 公開 / Astralyx 優秀賞 / Onplanetz インターン / Pokémon Cry 公開 / 卒研。

## 型の簡素化
旧多ページ用の未使用フィールド（works: category/cover/gallery/tags/description/version、profile: stats/perks/level/xp/history/bioQuote）を型から除去。works.test を新シェイプへ更新。

## ⚠️ 要確認（私が推定/補完した箇所）
- **活動の一部の日付は推定**（松尾研2026.6・大学院2026.4・Onplanetz2024.12 は履歴書の確定値。Astralyx優秀賞2026.3 / FASTBEAR公開2026.5 / Pokémon Cry公開2025.8 / 卒研2025.2 は概算）
- 修士研究のタイトル表記、各プロジェクトの year は適宜調整可
- 非公開リポ（Astralyx=sosu / PTCG-AI / お絵描き）はコード/デモリンクなし

## テスト
- [x] typecheck / lint(0err) / format / build — green、test 32 passed、Playwright smoke 3 passed