### PR TITLE
fix(chat): Gemini SSE の CRLF 対応で空応答バグ修正＋CI で Turnstile ビルド

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,10 @@ jobs:
 
       - name: Build
         working-directory: app
+        env:
+          # Public Turnstile site key — baked into the client bundle at build time
+          # so the widget renders. Leave the variable unset to ship without Turnstile.
+          VITE_TURNSTILE_SITEKEY: ${{ vars.VITE_TURNSTILE_SITEKEY }}
         run: npm run build
 
       - name: Deploy to Cloudflare Pages

--- a/app/functions/api/chat.ts
+++ b/app/functions/api/chat.ts
@@ -2,6 +2,7 @@
 import { buildSystemInstruction } from '../../src/lib/persona/persona';
 import { factCardIds } from '../../src/lib/persona/factCards';
 import { makeCitationGuard, type CitationGuard } from '../../src/lib/persona/citations';
+import { splitSSEEvents, extractDelta } from '../../src/lib/gemini-sse';
 
 interface Env {
   GEMINI_API_KEY?: string;
@@ -123,25 +124,13 @@ function relayStream(
           if (done) break;
           buffer += decoder.decode(value, { stream: true });
 
-          let sep: number;
-          while ((sep = buffer.indexOf('\n\n')) !== -1) {
-            const event = buffer.slice(0, sep);
-            buffer = buffer.slice(sep + 2);
-            const line = event.split('\n').find((l) => l.startsWith('data:'));
-            if (!line) continue;
-            const payload = line.slice(5).trim();
-            if (!payload || payload === '[DONE]') continue;
-            try {
-              const parsed = JSON.parse(payload) as {
-                candidates?: Array<{
-                  content?: { parts?: Array<{ text?: string }> };
-                }>;
-              };
-              const delta = parsed.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-              if (delta) emit(controller, guard.push(delta));
-            } catch {
-              // ignore malformed chunk
-            }
+          // Gemini separates SSE events with CRLF; splitSSEEvents handles both
+          // CRLF and LF (a plain '\n\n' split silently drops every chunk).
+          const { events, rest } = splitSSEEvents(buffer);
+          buffer = rest;
+          for (const event of events) {
+            const delta = extractDelta(event);
+            if (delta) emit(controller, guard.push(delta));
           }
         }
         emit(controller, guard.flush());

--- a/app/src/lib/gemini-sse.test.ts
+++ b/app/src/lib/gemini-sse.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { extractDelta, splitSSEEvents } from './gemini-sse';
+
+const evt = (text: string) =>
+  `data: ${JSON.stringify({ candidates: [{ content: { parts: [{ text }] } }] })}`;
+
+describe('splitSSEEvents', () => {
+  it('splits CRLF-separated events (Gemini real format)', () => {
+    const { events, rest } = splitSSEEvents(`${evt('A')}\r\n\r\n${evt('B')}\r\n\r\n`);
+    expect(events).toHaveLength(2);
+    expect(rest).toBe('');
+    expect(events.map(extractDelta)).toEqual(['A', 'B']);
+  });
+
+  it('also handles LF-separated events', () => {
+    const { events } = splitSSEEvents(`${evt('A')}\n\n${evt('B')}\n\n`);
+    expect(events.map(extractDelta)).toEqual(['A', 'B']);
+  });
+
+  it('carries an unterminated tail in rest', () => {
+    const { events, rest } = splitSSEEvents(`${evt('A')}\r\n\r\ndata: {"partial`);
+    expect(events.map(extractDelta)).toEqual(['A']);
+    expect(rest).toBe('data: {"partial');
+  });
+});
+
+describe('extractDelta', () => {
+  it('pulls the text out of a data event', () => {
+    expect(extractDelta(evt('こんにちは'))).toBe('こんにちは');
+  });
+
+  it('ignores [DONE], blank, and malformed events', () => {
+    expect(extractDelta('data: [DONE]')).toBe('');
+    expect(extractDelta('data:')).toBe('');
+    expect(extractDelta('data: not-json')).toBe('');
+    expect(extractDelta(': comment line')).toBe('');
+  });
+});

--- a/app/src/lib/gemini-sse.ts
+++ b/app/src/lib/gemini-sse.ts
@@ -1,0 +1,42 @@
+/**
+ * Parsing helpers for Gemini's streamGenerateContent SSE output.
+ *
+ * Gemini separates events with CRLF (`\r\n\r\n`), so a naive `\n\n` split never
+ * matches and drops every chunk. These helpers handle both CRLF and LF and are
+ * unit-tested, since the chat stream silently breaks if this is wrong.
+ */
+
+/** Boundary between SSE events: a blank line, CRLF or LF. */
+const EVENT_BOUNDARY = /\r?\n\r?\n/;
+
+/**
+ * Splits a streamed buffer into complete SSE events plus the unterminated tail
+ * to carry into the next read.
+ */
+export function splitSSEEvents(buffer: string): { events: string[]; rest: string } {
+  const events: string[] = [];
+  let rest = buffer;
+  for (;;) {
+    const m = EVENT_BOUNDARY.exec(rest);
+    if (!m) break;
+    events.push(rest.slice(0, m.index));
+    rest = rest.slice(m.index + m[0].length);
+  }
+  return { events, rest };
+}
+
+/** Extracts the text delta from one SSE event, or '' if there is none. */
+export function extractDelta(event: string): string {
+  const line = event.split('\n').find((l) => l.startsWith('data:'));
+  if (!line) return '';
+  const payload = line.slice(5).trim();
+  if (!payload || payload === '[DONE]') return '';
+  try {
+    const parsed = JSON.parse(payload) as {
+      candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+    };
+    return parsed.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
## 重要バグ修正：本番チャットが空応答だった
`wrangler pages deploy` で本番に出したところ、チャットが `{"done":true}` だけ返し**本文が空**だった。原因は **Gemini の SSE がイベント区切りに CRLF（`\r\n\r\n`）を使う**のに、`relayStream` が LF（`\n\n`）で分割していたため**1イベントもパースできていなかった**（元の `chat.ts` から潜在）。

### 修正
- SSE パースを純関数 `src/lib/gemini-sse.ts`（`splitSSEEvents` / `extractDelta`）に抽出し **CRLF/LF 両対応**＋ユニットテスト（5件）
- `functions/api/chat.ts` の `relayStream` をこの関数に差し替え
- **本番(pages.dev)で接地＋`[id]`引用＋本人の声色つきストリーミング回答を実機確認済み**

## CI 自動デプロイ：Turnstile 対応
- `deploy.yml` の build ステップに `VITE_TURNSTILE_SITEKEY`（GitHub Variable）を渡し、CI ビルドで Turnstile ウィジェットをバンドルに含められるように

## テスト
vitest **60 passed** / typecheck・lint・build green