### PR TITLE
feat(data): 各活動・作品に出典/公式ページの URL を添付

### DIFF
--- a/app/src/components/editorial/EditorialSite.tsx
+++ b/app/src/components/editorial/EditorialSite.tsx
@@ -187,6 +187,18 @@ export function EditorialSite() {
                         demo ↗
                       </a>
                     )}
+                    {(w.links.sources ?? []).map((s) => (
+                      <a
+                        key={s.url}
+                        href={s.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        aria-label={`${w.title}: ${s.label}`}
+                        className="text-on-surface-variant hover:text-primary hover:underline"
+                      >
+                        {s.label} ↗
+                      </a>
+                    ))}
                   </p>
                 </div>
               </motion.li>
@@ -229,7 +241,24 @@ export function EditorialSite() {
                 <span className="col-span-8 md:col-span-2 font-mono text-[11px] uppercase tracking-widest text-secondary">
                   [{CATEGORY_LABEL[a.category]}]
                 </span>
-                <span className="col-span-12 md:col-span-8 font-bold">{a.title}</span>
+                <span className="col-span-12 md:col-span-8 font-bold">
+                  {a.title}
+                  {a.links.length > 0 && (
+                    <span className="ml-2 inline-flex flex-wrap gap-x-3 font-mono text-[11px] font-normal">
+                      {a.links.map((l) => (
+                        <a
+                          key={l.url}
+                          href={l.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-primary hover:underline"
+                        >
+                          {l.label} ↗
+                        </a>
+                      ))}
+                    </span>
+                  )}
+                </span>
               </li>
             ))}
           </ul>

--- a/app/src/components/terminal/TerminalSite.tsx
+++ b/app/src/components/terminal/TerminalSite.tsx
@@ -177,6 +177,18 @@ export function TerminalSite() {
                       demo ↗
                     </a>
                   )}
+                  {(w.links.sources ?? []).map((s) => (
+                    <a
+                      key={s.url}
+                      href={s.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label={`${w.title}: ${s.label}`}
+                      className={`${MUTED} hover:text-[#2DD4BF] hover:underline`}
+                    >
+                      {s.label} ↗
+                    </a>
+                  ))}
                 </div>
               </article>
             ))}
@@ -215,6 +227,17 @@ export function TerminalSite() {
                   <span className={MUTED}>{formatDate(a.date)}</span>
                   <span className={`${GREEN} text-[12px]`}>[{CATEGORY_LABEL[a.category]}]</span>
                   <span className="text-[#E6EDF3]/90">{a.title}</span>
+                  {a.links.map((l) => (
+                    <a
+                      key={l.url}
+                      href={l.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className={`${ACCENT} text-[12px] hover:underline`}
+                    >
+                      {l.label} ↗
+                    </a>
+                  ))}
                 </li>
               ))}
             </ul>

--- a/app/src/data/activity.json
+++ b/app/src/data/activity.json
@@ -24,7 +24,18 @@
     "category": "release",
     "summary": "クマ出没情報を自動収集・構造化する AI エージェントを開発し公開。",
     "tags": ["ai-agent", "oss"],
-    "links": [{ "label": "Demo", "url": "https://fastbear.aisometry.com/" }]
+    "links": [
+      { "label": "Demo", "url": "https://fastbear.aisometry.com/" },
+      { "label": "アオタケ", "url": "https://aizu-startups-foundation.com/aotake/2025" },
+      {
+        "label": "成果報告",
+        "url": "https://miyagi.publishing.3rd-in.co.jp/article/e407a446-fdca-11f0-92e7-9ca3ba0a67df"
+      },
+      {
+        "label": "プレスリリース",
+        "url": "https://prtimes.jp/main/html/rd/p/000000002.000175363.html"
+      }
+    ]
   },
   {
     "id": "astralyx-award",
@@ -33,7 +44,12 @@
     "category": "award",
     "summary": "視聴履歴を 3D 可視化し AI が分析するアプリで優秀賞。AI パイプライン・3D 可視化を主担当。",
     "tags": ["hackathon", "award"],
-    "links": []
+    "links": [
+      {
+        "label": "GDGoC Japan Hackathon 2026",
+        "url": "https://gdg.community.dev/events/details/google-gdg-on-campus-university-of-aizu-fukushima-japan-presents-gdgoc-japan-hackathon/"
+      }
+    ]
   },
   {
     "id": "onplanetz-intern",

--- a/app/src/data/works.json
+++ b/app/src/data/works.json
@@ -6,7 +6,14 @@
     "tech": ["Next.js", "Three.js (R3F)", "Go", "Gemini", "Vertex AI"],
     "status": "ハッカソン優秀賞 · Team",
     "year": 2026,
-    "links": {}
+    "links": {
+      "sources": [
+        {
+          "label": "GDGoC Japan Hackathon 2026",
+          "url": "https://gdg.community.dev/events/details/google-gdg-on-campus-university-of-aizu-fukushima-japan-presents-gdgoc-japan-hackathon/"
+        }
+      ]
+    }
   },
   {
     "id": "llm-kv-cache",
@@ -24,7 +31,20 @@
     "tech": ["Python", "Gemini", "LangGraph", "Supabase", "Next.js", "Leaflet"],
     "status": "公開中 · Team（アオタケ採択）",
     "year": 2025,
-    "links": { "demo": "https://fastbear.aisometry.com/" }
+    "links": {
+      "demo": "https://fastbear.aisometry.com/",
+      "sources": [
+        { "label": "アオタケ", "url": "https://aizu-startups-foundation.com/aotake/2025" },
+        {
+          "label": "成果報告",
+          "url": "https://miyagi.publishing.3rd-in.co.jp/article/e407a446-fdca-11f0-92e7-9ca3ba0a67df"
+        },
+        {
+          "label": "プレスリリース",
+          "url": "https://prtimes.jp/main/html/rd/p/000000002.000175363.html"
+        }
+      ]
+    }
   },
   {
     "id": "dm-ai",
@@ -51,7 +71,20 @@
     "tech": ["Python", "Docker", "Kaggle"],
     "status": "コンペ · Team",
     "year": 2026,
-    "links": { "demo": "https://www.kaggle.com/sshow14" }
+    "links": {
+      "demo": "https://www.kaggle.com/sshow14",
+      "sources": [
+        { "label": "公式", "url": "https://ptcg-abc.pokemon.co.jp/" },
+        {
+          "label": "Kaggle: ABC",
+          "url": "https://www.kaggle.com/competitions/pokemon-tcg-ai-battle/overview"
+        },
+        {
+          "label": "Kaggle: Strategy",
+          "url": "https://www.kaggle.com/competitions/pokemon-tcg-ai-battle-challenge-strategy/overview"
+        }
+      ]
+    }
   },
   {
     "id": "oekaki-battler",
@@ -60,7 +93,9 @@
     "tech": ["Python", "Gemini", "Pygame", "LINE Bot"],
     "status": "学園祭企画 · 個人",
     "year": 2025,
-    "links": {}
+    "links": {
+      "sources": [{ "label": "学園祭公式", "url": "https://soshosai.com/" }]
+    }
   },
   {
     "id": "textworld-rl",

--- a/app/src/lib/persona/factCards.test.ts
+++ b/app/src/lib/persona/factCards.test.ts
@@ -51,6 +51,12 @@ describe('buildFactCards', () => {
     expect(text).toContain('https://github.com/shiyow5/DuelMasters-AI');
   });
 
+  it('surfaces work and activity source links for citing provenance', () => {
+    // a work source (PTCG official page) and an activity source (GDGoC event)
+    expect(text).toContain('https://ptcg-abc.pokemon.co.jp/');
+    expect(text).toContain('gdg.community.dev');
+  });
+
   it('never emits a citation token that is not a known id', () => {
     const ids = factCardIds();
     for (const m of text.matchAll(CITATION_RE)) {

--- a/app/src/lib/persona/factCards.ts
+++ b/app/src/lib/persona/factCards.ts
@@ -22,7 +22,11 @@ export function factCardIds(): ReadonlySet<string> {
 }
 
 function workLinks(links: (typeof WORKS)[number]['links']): string {
-  const urls = Object.values(links).filter(Boolean) as string[];
+  const urls: string[] = [];
+  if (links.github) urls.push(links.github);
+  if (links.demo) urls.push(links.demo);
+  if (links.play) urls.push(links.play);
+  for (const s of links.sources ?? []) urls.push(`${s.label}: ${s.url}`);
   return urls.length ? urls.join(' , ') : 'なし';
 }
 
@@ -41,9 +45,11 @@ export function buildFactCards(): string {
       `技術: ${w.tech.join(', ')}. リンク: ${workLinks(w.links)}`,
   );
 
-  const activities = ACTIVITIES.map(
-    (a) => `- [act:${a.id}] ${formatDate(a.date)} ${a.title} — ${a.summary}`,
-  );
+  const activities = ACTIVITIES.map((a) => {
+    const sources = a.links.map((l) => `${l.label}: ${l.url}`).join(' , ');
+    const base = `- [act:${a.id}] ${formatDate(a.date)} ${a.title} — ${a.summary}`;
+    return sources ? `${base} 出典: ${sources}` : base;
+  });
 
   return [
     '# 事実カード（FACT CARDS）',

--- a/app/src/lib/works.test.ts
+++ b/app/src/lib/works.test.ts
@@ -26,11 +26,24 @@ describe('WORKS catalogue', () => {
 
   it('only exposes absolute http(s) links (no placeholders)', () => {
     for (const work of WORKS) {
-      for (const url of Object.values(work.links)) {
-        if (url) {
-          expect(url).toMatch(/^https?:\/\//);
-          expect(url).not.toContain('example.com');
-        }
+      const urls = [
+        work.links.github,
+        work.links.demo,
+        work.links.play,
+        ...(work.links.sources ?? []).map((s) => s.url),
+      ].filter(Boolean) as string[];
+      for (const url of urls) {
+        expect(url).toMatch(/^https?:\/\//);
+        expect(url).not.toContain('example.com');
+      }
+    }
+  });
+
+  it('gives every source link a label and absolute url', () => {
+    for (const work of WORKS) {
+      for (const source of work.links.sources ?? []) {
+        expect(source.label).toBeTruthy();
+        expect(source.url).toMatch(/^https?:\/\//);
       }
     }
   });

--- a/app/src/lib/works.ts
+++ b/app/src/lib/works.ts
@@ -1,9 +1,16 @@
 import raw from '../data/works.json';
 
+export interface WorkSource {
+  label: string;
+  url: string;
+}
+
 export interface WorkLinks {
   github?: string;
   demo?: string;
   play?: string;
+  /** Labeled source/reference links (official event page, press, competition). */
+  sources?: WorkSource[];
 }
 
 export interface Work {


### PR DESCRIPTION
## 概要
各活動・作品に「その出典/公式ページ」の URL を添付し、両モードで表示。クローンも出典を引用可能に。

## 追加した出典
- **Astralyx / 優秀賞** → GDGoC Japan Hackathon 2026
- **FASTBEAR** → アオタケ公式・成果報告記事・プレスリリース
- **PTCG-AI** → ポケモン公式・Kaggle（ABC / Strategy）
- **お絵描きバトラー** → 学園祭公式

## 変更
- `works.ts`: `WorkLinks.sources`（`{label,url}[]`）を追加
- `works.json` / `activity.json`: 上記 URL を追加
- `EditorialSite` / `TerminalSite`: 作品・活動の出典リンクを両モードで描画（活動セクションは従来リンク非表示だったため新規対応）
- `factCards.ts`: 作品リンク＋活動出典を fact cards に反映（クローンが出典 URL を引用できる）

## テスト
vitest **62 passed**（works/factCards に出典検証を追加）/ typecheck・lint・build green。両モードでスクショ確認済み。