### PR TITLE
fix(ci): Deploy の必須CI検証をポーリング化（push 競合の修正）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,7 @@ jobs:
           import json
           import os
           import sys
+          import time
           import urllib.request
 
           required = {"Format Check", "Lint", "Test"}
@@ -72,47 +73,65 @@ jobs:
               f"?head_sha={sha}&per_page=100"
           )
 
-          request = urllib.request.Request(
-              url,
-              headers={
-                  "Accept": "application/vnd.github+json",
-                  "Authorization": f"Bearer {token}",
-                  "X-GitHub-Api-Version": "2022-11-28",
-              },
-          )
-          with urllib.request.urlopen(request) as response:
-              runs = json.load(response).get("workflow_runs", [])
+          def latest_runs():
+              request = urllib.request.Request(
+                  url,
+                  headers={
+                      "Accept": "application/vnd.github+json",
+                      "Authorization": f"Bearer {token}",
+                      "X-GitHub-Api-Version": "2022-11-28",
+                  },
+              )
+              with urllib.request.urlopen(request) as response:
+                  runs = json.load(response).get("workflow_runs", [])
+              latest = {}
+              for run in runs:
+                  name = run.get("name")
+                  if name not in required:
+                      continue
+                  created = run.get("created_at", "")
+                  if created > latest.get(name, {}).get("created_at", ""):
+                      latest[name] = run
+              return latest
 
-          latest = {}
-          for run in runs:
-              name = run.get("name")
-              if name not in required:
-                  continue
-              created = run.get("created_at", "")
-              if created > latest.get(name, {}).get("created_at", ""):
-                  latest[name] = run
-
-          failures = []
-          for name in sorted(required):
-              run = latest.get(name)
-              if run is None:
-                  failures.append(f"{name}: no run found for {sha}")
-                  continue
-              status = run.get("status")
-              conclusion = run.get("conclusion")
-              if status != "completed" or conclusion != "success":
-                  failures.append(
-                      f"{name}: status={status!r} conclusion={conclusion!r} "
-                      f"url={run.get('html_url')}"
-                  )
-
-          if failures:
-              print("Deploy blocked — required CI not green on this commit:")
-              for failure in failures:
-                  print(f"  - {failure}")
-              sys.exit(1)
-
-          print(f"All required CI passed for {sha}.")
+          # On push, this Deploy job starts concurrently with the required CI
+          # workflows, so poll until they finish instead of failing on the race.
+          # A required workflow that never registers a run within the grace window
+          # wasn't triggered for this change (paths unchanged) — treat as N/A.
+          start = time.time()
+          grace = 90
+          deadline = start + 360
+          while True:
+              latest = latest_runs()
+              pending, missing, failures = [], [], []
+              for name in sorted(required):
+                  run = latest.get(name)
+                  if run is None:
+                      missing.append(name)
+                  elif run.get("status") != "completed":
+                      pending.append(name)
+                  elif run.get("conclusion") != "success":
+                      failures.append(
+                          f"{name}: conclusion={run.get('conclusion')!r} "
+                          f"url={run.get('html_url')}"
+                      )
+              if failures:
+                  print("Deploy blocked — required CI failed on this commit:")
+                  for failure in failures:
+                      print(f"  - {failure}")
+                  sys.exit(1)
+              if not pending and not missing:
+                  print(f"All required CI passed for {sha}.")
+                  break
+              if not pending and missing and (time.time() - start) > grace:
+                  print("Required CI not triggered for this change (proceeding): " + ", ".join(missing))
+                  break
+              if time.time() > deadline:
+                  waiting = pending + missing
+                  print("Deploy blocked — timed out waiting for required CI: " + ", ".join(waiting))
+                  sys.exit(1)
+              print("Waiting for required CI: " + ", ".join(pending + missing))
+              time.sleep(10)
           PY
 
       - name: Setup Frontend


### PR DESCRIPTION
push 時に Deploy が Format/Lint/Test と同時に走り、未完了を not-green と誤判定して毎回失敗していた競合を修正。required CI の完了をポーリングで待ち、app/** 以外の変更で起動しない場合は猶予(90s)後に続行、失敗時は即ブロック。embedded Python は構文検証済み。