### PR TITLE
feat(chat): クローンの [id] 引用をクリック可能なリンクに

### DIFF
--- a/app/src/components/chat/ChatWidget.tsx
+++ b/app/src/components/chat/ChatWidget.tsx
@@ -1,9 +1,53 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { Send, X } from 'lucide-react';
 import { streamChat, type ChatMessage } from '../../lib/chat';
 import { useMode, type Mode } from '../../lib/mode';
+import { resolveCitation } from '../../lib/persona/citationLinks';
 import { useTurnstile } from '../../lib/turnstile';
+
+const CITATION_RE = /\[([a-z]+:[a-z0-9-]+)\]/g;
+
+/** Renders assistant text, turning `[id]` citations into clickable links. */
+function CitedText({
+  content,
+  mode,
+  linkClass,
+  onInternal,
+}: {
+  content: string;
+  mode: Mode;
+  linkClass: string;
+  onInternal: () => void;
+}): ReactNode {
+  const nodes: ReactNode[] = [];
+  let last = 0;
+  let key = 0;
+  for (const m of content.matchAll(CITATION_RE)) {
+    const start = m.index ?? 0;
+    if (start > last) nodes.push(content.slice(last, start));
+    const c = resolveCitation(m[1]!, mode);
+    if (c) {
+      nodes.push(
+        <a
+          key={`c-${key++}`}
+          href={c.href}
+          title={c.label}
+          className={linkClass}
+          {...(c.external ? { target: '_blank', rel: 'noreferrer' } : { onClick: onInternal })}
+        >
+          [{c.slug}
+          {c.external ? ' ↗' : ''}]
+        </a>,
+      );
+    } else {
+      nodes.push(m[0]);
+    }
+    last = start + m[0].length;
+  }
+  if (last < content.length) nodes.push(content.slice(last));
+  return nodes;
+}
 
 const CHARACTER_SRC = '/characters/shiyow.png';
 const TURNSTILE_SITEKEY = import.meta.env.VITE_TURNSTILE_SITEKEY as string | undefined;
@@ -35,6 +79,7 @@ interface ChatTheme {
   msgUser: string;
   msgAssistant: string;
   msgError: string;
+  citation: string;
   form: string;
   input: string;
   sendBtn: string;
@@ -55,6 +100,8 @@ const THEMES: Record<Mode, ChatTheme> = {
     msgUser: 'bg-primary border-2 border-primary text-on-primary',
     msgAssistant: 'bg-surface-container-low border-2 border-on-surface/20 text-on-surface',
     msgError: 'bg-error-container border-2 border-error text-on-error',
+    citation:
+      'font-mono text-[11px] text-primary underline decoration-dotted underline-offset-2 hover:bg-primary/10',
     form: 'border-t-2 border-on-surface bg-surface-container-low',
     input: 'bg-surface-container-lowest border-2 border-on-surface/30 focus:border-primary',
     sendBtn: 'bg-primary text-on-primary border-2 border-primary',
@@ -73,6 +120,8 @@ const THEMES: Record<Mode, ChatTheme> = {
     msgUser: 'bg-[#2DD4BF]/15 border border-[#2DD4BF]/40 text-[#E6EDF3]',
     msgAssistant: 'bg-[#161B22] border border-[#30363D] text-[#E6EDF3]/90',
     msgError: 'bg-[#FF6B6B]/15 border border-[#FF6B6B] text-[#FF6B6B]',
+    citation:
+      'text-[11px] text-[#2DD4BF] underline decoration-dotted underline-offset-2 hover:bg-[#2DD4BF]/10',
     form: 'border-t border-[#30363D] bg-[#0D1117]',
     input: 'bg-[#0D1117] border border-[#30363D] text-[#E6EDF3] focus:border-[#2DD4BF]',
     sendBtn: 'bg-[#2DD4BF] text-[#0D1117] border border-[#2DD4BF]',
@@ -282,7 +331,22 @@ export function ChatWidget() {
                       m.role === 'user' ? t.msgUser : m.error ? t.msgError : t.msgAssistant
                     }`}
                   >
-                    {m.content || (m.pending ? '…' : '')}
+                    {m.content ? (
+                      m.role === 'assistant' && !m.error ? (
+                        <CitedText
+                          content={m.content}
+                          mode={mode}
+                          linkClass={t.citation}
+                          onInternal={() => setOpen(false)}
+                        />
+                      ) : (
+                        m.content
+                      )
+                    ) : m.pending ? (
+                      '…'
+                    ) : (
+                      ''
+                    )}
                     {m.pending && m.content && (
                       <span className="inline-block w-2 h-4 bg-current ml-1 animate-pulse align-text-bottom" />
                     )}

--- a/app/src/lib/persona/citationLinks.test.ts
+++ b/app/src/lib/persona/citationLinks.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCitation } from './citationLinks';
+
+describe('resolveCitation', () => {
+  it('links a work with a URL out to its source (external)', () => {
+    const c = resolveCitation('work:fastbear', 'editorial');
+    expect(c?.external).toBe(true);
+    expect(c?.href).toMatch(/^https?:\/\//);
+    expect(c?.slug).toBe('fastbear');
+  });
+
+  it('links a work without any URL to the in-page work section (per mode)', () => {
+    expect(resolveCitation('work:llm-kv-cache', 'editorial')?.href).toBe('#work');
+    expect(resolveCitation('work:llm-kv-cache', 'terminal')?.href).toBe('#projects');
+    expect(resolveCitation('work:llm-kv-cache', 'editorial')?.external).toBe(false);
+  });
+
+  it('links an activity with a source URL externally', () => {
+    const c = resolveCitation('act:astralyx-award', 'editorial');
+    expect(c?.external).toBe(true);
+    expect(c?.href).toContain('gdg.community.dev');
+  });
+
+  it('links a link-less activity to the activity section', () => {
+    expect(resolveCitation('act:matsuo-intern', 'terminal')?.href).toBe('#activity');
+  });
+
+  it('links a profile group to the stack/skills section per mode', () => {
+    expect(resolveCitation('prof:ai', 'editorial')?.href).toBe('#stack');
+    expect(resolveCitation('prof:ai', 'terminal')?.href).toBe('#skills');
+  });
+
+  it('returns null for unknown ids and malformed tokens', () => {
+    expect(resolveCitation('work:does-not-exist', 'editorial')).toBeNull();
+    expect(resolveCitation('not-a-citation', 'editorial')).toBeNull();
+    expect(resolveCitation('prof:identity', 'editorial')?.href).toBe('#stack');
+  });
+});

--- a/app/src/lib/persona/citationLinks.ts
+++ b/app/src/lib/persona/citationLinks.ts
@@ -1,0 +1,66 @@
+/**
+ * Resolves a clone citation id (e.g. `work:fastbear`, `act:astralyx-award`,
+ * `prof:ai`) to a navigable link so the chat can render `[id]` tokens as real,
+ * clickable references instead of dead text.
+ *
+ * Works/activities with a URL link out to their source; everything else links
+ * to the matching in-page section (anchors differ per mode).
+ */
+import { WORKS } from '../works';
+import { ACTIVITIES } from '../activity';
+import { PROFILE } from '../profile';
+import type { Mode } from '../mode';
+
+const ANCHORS: Record<Mode, { work: string; activity: string; stack: string }> = {
+  editorial: { work: 'work', activity: 'activity', stack: 'stack' },
+  terminal: { work: 'projects', activity: 'activity', stack: 'skills' },
+};
+
+export interface ResolvedCitation {
+  id: string;
+  slug: string;
+  href: string;
+  external: boolean;
+  label: string;
+}
+
+const CITATION = /^([a-z]+):([a-z0-9-]+)$/;
+
+export function resolveCitation(raw: string, mode: Mode): ResolvedCitation | null {
+  const m = CITATION.exec(raw);
+  if (!m) return null;
+  const type = m[1]!;
+  const slug = m[2]!;
+  const anchors = ANCHORS[mode];
+
+  if (type === 'work') {
+    const w = WORKS.find((x) => x.id === slug);
+    if (!w) return null;
+    const url = w.links.demo ?? w.links.play ?? w.links.github ?? w.links.sources?.[0]?.url;
+    return url
+      ? { id: raw, slug, href: url, external: true, label: w.title }
+      : { id: raw, slug, href: `#${anchors.work}`, external: false, label: w.title };
+  }
+
+  if (type === 'act') {
+    const a = ACTIVITIES.find((x) => x.id === slug);
+    if (!a) return null;
+    const url = a.links[0]?.url;
+    return url
+      ? { id: raw, slug, href: url, external: true, label: a.title }
+      : { id: raw, slug, href: `#${anchors.activity}`, external: false, label: a.title };
+  }
+
+  if (type === 'prof') {
+    const g = PROFILE.techStack.find((x) => x.id === slug);
+    return {
+      id: raw,
+      slug,
+      href: `#${anchors.stack}`,
+      external: false,
+      label: g?.label ?? 'プロフィール',
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
クローン回答中の `[work:fastbear]` 等の引用が、リンクに見えるのに飛べなかった問題を解消。出典 URL があれば外部リンク（作品の demo/github/source・活動の出典）、無ければ該当セクションへ内部アンカー（モード別: editorial #work/#stack, terminal #projects/#skills）。`resolveCitation` を単体テスト（6件）、ChatWidget で `CitedText` 描画。vitest 68 passed。