### PR TITLE
fix(data): PTCG-AI の担当範囲を訂正＋進行中に

### DIFF
--- a/app/src/data/works.json
+++ b/app/src/data/works.json
@@ -67,9 +67,9 @@
   {
     "id": "ptcg-ai",
     "title": "PTCG-AI Battle Challenge",
-    "tagline": "ポケモンカード AI エージェント（Kaggle「Pokemon TCG AI Battle」）。戦略決定ロジックの実装・学習・評価を担当し、Docker で再現可能な提出パイプラインとエージェント同士の対戦テストを整備。",
-    "tech": ["Python", "Docker", "Kaggle"],
-    "status": "コンペ · Team",
+    "tagline": "ポケモンカード AI エージェント（Kaggle「Pokemon TCG AI Battle」）。戦略決定ロジックの実装・学習・評価を担当。提出パイプラインや対戦テストの整備はチームメンバーが担当。現在進行中のプロジェクト。",
+    "tech": ["Python", "Kaggle"],
+    "status": "コンペ進行中 · Team",
     "year": 2026,
     "links": {
       "demo": "https://www.kaggle.com/sshow14",


### PR DESCRIPTION
ユーザー確認による訂正。Docker 提出パイプライン・対戦テスト整備はチームメンバー担当のため tagline から本人担当として外し、本人の担当（戦略決定ロジックの実装・学習・評価）に限定。プロジェクトは現在進行中（status: コンペ進行中 · Team）。tech から Docker を除外。