### PR TITLE
chore(infra): KV レート制限を有効化（RATE_LIMIT_KV バインド）

### DIFF
--- a/app/wrangler.toml
+++ b/app/wrangler.toml
@@ -4,13 +4,11 @@ compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "dist"
 
 # KV namespace used by functions/api/chat.ts for per-IP rate limiting.
-# The id/preview_id must be set via the Cloudflare dashboard or `wrangler kv:namespace create`.
-# See docs/SETUP_CLOUDFLARE.md §9.
-#
-# [[kv_namespaces]]
-# binding = "RATE_LIMIT_KV"
-# id = "REPLACE_WITH_KV_ID"
-# preview_id = "REPLACE_WITH_PREVIEW_KV_ID"
+# Created via `wrangler kv namespace create RATE_LIMIT_KV`. See docs/SETUP_CLOUDFLARE.md §9.
+[[kv_namespaces]]
+binding = "RATE_LIMIT_KV"
+id = "d0af105b523f4804ac16f1a0482e5c05"
+preview_id = "d0af105b523f4804ac16f1a0482e5c05"
 
 # Runtime secrets are stored via the Pages dashboard, NOT this file:
 #   GEMINI_API_KEY


### PR DESCRIPTION
wrangler kv namespace create で作成した KV を wrangler.toml にバインドし、chat.ts の per-IP レート制限（12/分・60/時）を有効化。Gemini 従量枠の悪用防止。