### PR TITLE
feat(activity): 全体タイムライン化（学歴追加・日付を月まで）

### DIFF
--- a/app/src/components/editorial/EditorialSite.tsx
+++ b/app/src/components/editorial/EditorialSite.tsx
@@ -223,14 +223,14 @@ export function EditorialSite() {
 
         {/* ===== activity ===== */}
         <motion.section id="activity" className="py-12 md:py-16" {...reveal}>
-          <SectionHead index="03" title="Activity" note="直近の活動" />
+          <SectionHead index="03" title="Activity" note="タイムライン" />
           {ACTIVITIES.length === 0 && (
             <p className="border-t-2 border-on-surface/15 py-3 font-mono text-sm text-on-surface-variant">
               {'// 準備中'}
             </p>
           )}
           <ul>
-            {ACTIVITIES.slice(0, 7).map((a) => (
+            {ACTIVITIES.map((a) => (
               <li
                 key={a.id}
                 className="grid grid-cols-12 gap-3 border-t-2 border-on-surface/15 py-3 items-baseline"

--- a/app/src/components/terminal/TerminalSite.tsx
+++ b/app/src/components/terminal/TerminalSite.tsx
@@ -219,10 +219,10 @@ export function TerminalSite() {
 
         {/* activity */}
         <section id="activity" className="mt-10">
-          <SectionLabel>activity.log — 直近の活動</SectionLabel>
+          <SectionLabel>activity.log — タイムライン</SectionLabel>
           <div className="rounded-md border border-[#30363D] bg-[#161B22] p-4">
             <ul className="space-y-2 text-[13px]">
-              {ACTIVITIES.slice(0, 6).map((a) => (
+              {ACTIVITIES.map((a) => (
                 <li key={a.id} className="flex flex-wrap items-baseline gap-x-3">
                   <span className={MUTED}>{formatDate(a.date)}</span>
                   <span className={`${GREEN} text-[12px]`}>[{CATEGORY_LABEL[a.category]}]</span>

--- a/app/src/data/activity.json
+++ b/app/src/data/activity.json
@@ -11,9 +11,9 @@
   {
     "id": "grad-school",
     "date": "2026-04-01",
-    "title": "大学院進学・LLM 効率化研究を開始",
-    "category": "project",
-    "summary": "会津大学大学院 Computer Science 専攻へ。長文脈 LLM 推論の KV キャッシュ効率化を研究。",
+    "title": "会津大学大学院 コンピュータ理工学研究科 入学",
+    "category": "education",
+    "summary": "コンピュータ理工学専攻へ。長文脈 LLM 推論の KV キャッシュ効率化を研究。",
     "tags": ["llm", "research"],
     "links": []
   },
@@ -78,6 +78,24 @@
     "category": "project",
     "summary": "RL エージェントを LSTM / Transformer / GPT-2 で比較し、知見を論文化。",
     "tags": ["rl", "research"],
+    "links": [{ "label": "卒業論文", "url": "/papers/textworld-rl-thesis.pdf" }]
+  },
+  {
+    "id": "bachelor-grad",
+    "date": "2026-03-01",
+    "title": "会津大学 コンピュータ理工学部 卒業",
+    "category": "education",
+    "summary": "コンピュータ理工学を専攻し卒業。",
+    "tags": ["education"],
+    "links": []
+  },
+  {
+    "id": "bachelor-enroll",
+    "date": "2022-04-01",
+    "title": "会津大学 コンピュータ理工学部 入学",
+    "category": "education",
+    "summary": "コンピュータ理工学を専攻。",
+    "tags": ["education"],
     "links": []
   }
 ]

--- a/app/src/lib/activity.test.ts
+++ b/app/src/lib/activity.test.ts
@@ -22,8 +22,8 @@ describe('ACTIVITIES', () => {
 });
 
 describe('formatDate', () => {
-  it('renders an ISO date as dotted segments', () => {
-    expect(formatDate('2026-04-22')).toBe('2026.04.22');
+  it('renders an ISO date as year.month (no day)', () => {
+    expect(formatDate('2026-04-22')).toBe('2026.04');
   });
 });
 
@@ -48,7 +48,7 @@ describe('groupByYear', () => {
 });
 
 describe('category lookup tables', () => {
-  const categories = ['project', 'release', 'talk', 'award', 'job', 'post'] as const;
+  const categories = ['project', 'release', 'talk', 'award', 'job', 'post', 'education'] as const;
 
   it('provides a label, icon and colour for every category', () => {
     for (const category of categories) {

--- a/app/src/lib/activity.ts
+++ b/app/src/lib/activity.ts
@@ -1,6 +1,13 @@
 import raw from '../data/activity.json';
 
-export type ActivityCategory = 'project' | 'release' | 'talk' | 'award' | 'job' | 'post';
+export type ActivityCategory =
+  | 'project'
+  | 'release'
+  | 'talk'
+  | 'award'
+  | 'job'
+  | 'post'
+  | 'education';
 
 export interface ActivityLink {
   label: string;
@@ -48,6 +55,7 @@ export const CATEGORY_LABEL: Record<ActivityCategory, string> = {
   award: 'Award',
   job: 'Job',
   post: 'Post',
+  education: 'Education',
 };
 
 export const CATEGORY_ICON: Record<ActivityCategory, string> = {
@@ -57,6 +65,7 @@ export const CATEGORY_ICON: Record<ActivityCategory, string> = {
   award: 'military_tech',
   job: 'work',
   post: 'edit_note',
+  education: 'school',
 };
 
 export const CATEGORY_COLOR: Record<ActivityCategory, string> = {
@@ -66,9 +75,10 @@ export const CATEGORY_COLOR: Record<ActivityCategory, string> = {
   award: 'bg-primary-container text-on-primary-container border-2 border-primary',
   job: 'bg-tertiary-container text-on-tertiary-container border-2 border-tertiary',
   post: 'bg-surface-container-highest text-on-surface border-2 border-outline',
+  education: 'bg-secondary-container text-on-secondary-container border-2 border-secondary',
 };
 
 export function formatDate(iso: string): string {
-  const [y, m, d] = iso.split('-');
-  return `${y}.${m}.${d}`;
+  const [y, m] = iso.split('-');
+  return `${y}.${m}`;
 }


### PR DESCRIPTION
- Activity 注記を「直近の活動」→「タイムライン」、全件表示に
- 学歴を追加: 学部入学(2022.04)/学部卒業(2026.03)/研究科入学(2026.04)。education カテゴリ新設
- 日付を 年.月 表示（日を省略）
- 卒業研究に卒業論文PDFリンク追加
vitest 73 passed。