### PR TITLE
feat(terminal): man/コマンド一覧プルダウン・回答リンク化・Turnstile非表示・コピー可・補完強化

### DIFF
--- a/app/src/components/terminal/TerminalRepl.tsx
+++ b/app/src/components/terminal/TerminalRepl.tsx
@@ -5,8 +5,10 @@ import { WORKS } from '../../lib/works';
 import { ACTIVITIES } from '../../lib/activity';
 import { streamChat } from '../../lib/chat';
 import { useTurnstile } from '../../lib/turnstile';
+import { tokenizeAssistantText } from '../../lib/persona/messageTokens';
 import {
   COMMANDS,
+  MANUAL,
   runCommand,
   type CmdCtx,
   type Line,
@@ -25,14 +27,34 @@ const TONE: Record<Tone, string> = {
 
 const ctx: CmdCtx = { works: WORKS, profile: PROFILE, activities: ACTIVITIES };
 
-/** Longest common prefix of a list of strings. */
 function lcp(items: string[]): string {
   if (!items.length) return '';
   let prefix = items[0]!;
-  for (const s of items) {
-    while (!s.startsWith(prefix)) prefix = prefix.slice(0, -1);
-  }
+  for (const s of items) while (!s.startsWith(prefix)) prefix = prefix.slice(0, -1);
   return prefix;
+}
+
+/** Renders assistant text with clickable citations / urls (for `ask` answers). */
+function RichLine({ text }: { text: string }) {
+  return (
+    <>
+      {tokenizeAssistantText(text, 'terminal').map((p, i) =>
+        p.kind === 'text' ? (
+          <span key={i}>{p.text}</span>
+        ) : (
+          <a
+            key={i}
+            href={p.href}
+            title={p.text}
+            className="text-[#2DD4BF] underline decoration-dotted underline-offset-2 hover:bg-[#2DD4BF]/10"
+            {...(p.external ? { target: '_blank', rel: 'noreferrer' } : {})}
+          >
+            {p.text}
+          </a>
+        ),
+      )}
+    </>
+  );
 }
 
 export function TerminalRepl() {
@@ -43,7 +65,10 @@ export function TerminalRepl() {
     { text: `${PROFILE.name} — ${title}` },
     { text: `LLM / Agent / RAG / ML · ${PROFILE.location}`, tone: 'muted' },
     { text: '' },
-    { text: '`help` でコマンド一覧。`ask <質問>` でクローンに直接質問できます。', tone: 'muted' },
+    {
+      text: '`help` か上の ▾ でコマンド一覧。`ask <質問>` でクローンに直接質問できます。',
+      tone: 'muted',
+    },
   ];
 
   const [output, setOutput] = useState<Line[]>(boot);
@@ -51,6 +76,7 @@ export function TerminalRepl() {
   const [history, setHistory] = useState<string[]>([]);
   const [histIdx, setHistIdx] = useState(-1);
   const [busy, setBusy] = useState(false);
+  const [manualOpen, setManualOpen] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -73,18 +99,22 @@ export function TerminalRepl() {
       return copy;
     });
 
+  const focus = () => inputRef.current?.focus();
+  // Don't steal focus mid-selection, otherwise the user can't copy console text.
+  const focusUnlessSelecting = () => {
+    if (window.getSelection()?.toString()) return;
+    inputRef.current?.focus();
+  };
+
   const ask = (question: string) => {
     if (enabled && !token) {
       append([
-        {
-          text: '認証（Turnstile）の確認中です。数秒おいてもう一度お試しください。',
-          tone: 'error',
-        },
+        { text: '認証（Turnstile）の確認中です。数秒おいてもう一度どうぞ。', tone: 'error' },
       ]);
       return;
     }
     setBusy(true);
-    append([{ text: '', tone: 'default' }]); // streaming target (always last)
+    append([{ text: '', tone: 'default', rich: true }]); // streaming target (always last)
     abortRef.current?.abort();
     abortRef.current = streamChat([{ role: 'user', content: question }], token, {
       onDelta: (d) => appendDelta(d),
@@ -99,14 +129,10 @@ export function TerminalRepl() {
     });
   };
 
-  const submit = () => {
-    if (busy) return;
-    const cmd = input;
-    setInput('');
-    setHistIdx(-1);
+  const exec = (cmd: string) => {
     if (cmd.trim()) setHistory((h) => [...h, cmd]);
+    setHistIdx(-1);
     append([{ text: `❯ ${cmd}`, tone: 'accent' }]);
-
     const res = runCommand(cmd, ctx);
     if (res.lines.length) append(res.lines);
     const a = res.action;
@@ -130,29 +156,46 @@ export function TerminalRepl() {
     }
   };
 
+  const submit = () => {
+    if (busy) return;
+    const cmd = input;
+    setInput('');
+    exec(cmd);
+  };
+
   const complete = () => {
     const parts = input.split(/\s+/);
+    const partial = parts[parts.length - 1]!;
+    let candidates: string[];
     if (parts.length <= 1) {
-      const matches = COMMANDS.filter((c) => c.startsWith(parts[0]!.toLowerCase()));
-      if (matches.length === 1) setInput(matches[0] + ' ');
-      else if (matches.length > 1) {
-        const p = lcp([...matches]);
-        if (p.length > parts[0]!.length) setInput(p);
-        else append([{ text: matches.join('  '), tone: 'muted' }]);
-      }
+      candidates = COMMANDS.filter((c) => c.startsWith(partial.toLowerCase()));
+    } else {
+      const head = parts[0]!.toLowerCase();
+      const files = ['mission.txt', 'contact.sh', 'status.txt', 'skills.json'];
+      candidates =
+        head === 'ls'
+          ? ['projects/']
+          : head === 'man'
+            ? MANUAL.map((m) => m.name)
+            : head === 'open'
+              ? WORKS.map((w) => w.id)
+              : head === 'cat'
+                ? [...files, ...WORKS.map((w) => `projects/${w.id}`)]
+                : [];
+      candidates = candidates.filter((c) => c.startsWith(partial));
+    }
+    if (!candidates.length) return;
+    if (candidates.length === 1) {
+      parts[parts.length - 1] = candidates[0]!;
+      setInput(parts.join(' ') + (parts.length <= 1 ? ' ' : ''));
       return;
     }
-    // second token: complete work ids for cat/open
-    const head = parts[0]!.toLowerCase();
-    if (head === 'open' || head === 'cat') {
-      const partial = parts[parts.length - 1]!.replace(/^projects\//, '');
-      const ids = WORKS.map((w) => w.id).filter((id) => id.startsWith(partial));
-      if (ids.length === 1) {
-        parts[parts.length - 1] = head === 'cat' ? `projects/${ids[0]}` : ids[0]!;
-        setInput(parts.join(' '));
-      } else if (ids.length > 1) {
-        append([{ text: ids.join('  '), tone: 'muted' }]);
-      }
+    const p = lcp(candidates);
+    if (p.length > partial.length) {
+      parts[parts.length - 1] = p;
+      setInput(parts.join(' '));
+    } else {
+      append([{ text: candidates.join('  '), tone: 'muted' }]);
     }
   };
 
@@ -186,11 +229,46 @@ export function TerminalRepl() {
   return (
     <section
       id="home"
-      onClick={() => inputRef.current?.focus()}
-      className="border-x border-b border-[#30363D] bg-[#0D1117] p-6 md:p-8"
+      className="relative border-x border-b border-[#30363D] bg-[#0D1117] p-4 md:p-6"
     >
-      <div ref={scrollRef} className="max-h-[52vh] overflow-y-auto">
-        <div className="space-y-1">
+      <div className="mb-2 flex items-center justify-between text-[12px]">
+        <span className={TONE.muted}>~/shiyow.dev — interactive</span>
+        <button
+          type="button"
+          onClick={() => setManualOpen((v) => !v)}
+          aria-expanded={manualOpen}
+          className="rounded-md border border-[#30363D] px-2.5 py-1 text-[#8B949E] hover:border-[#2DD4BF] hover:text-[#2DD4BF]"
+        >
+          ▾ コマンド一覧
+        </button>
+      </div>
+
+      {manualOpen && (
+        <div className="absolute right-4 top-12 z-30 max-h-[300px] w-[min(420px,calc(100%-2rem))] overflow-y-auto rounded-md border border-[#30363D] bg-[#161B22] p-2 shadow-[0_8px_30px_rgba(0,0,0,0.5)]">
+          {MANUAL.map((m) => (
+            <button
+              key={m.name}
+              type="button"
+              onClick={() => {
+                setManualOpen(false);
+                setInput(m.name + ' ');
+                focus();
+              }}
+              className="block w-full rounded px-2 py-1.5 text-left hover:bg-[#0D1117]"
+            >
+              <span className={`${TONE.accent} text-[13px]`}>{m.name}</span>{' '}
+              <span className="text-[11px] text-[#8B949E]">{m.usage}</span>
+              <span className="block text-[11px] text-[#8B949E]">{m.desc}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div
+        onClick={focusUnlessSelecting}
+        className="flex h-[clamp(300px,46vh,480px)] select-text flex-col rounded-md bg-[#0D1117]"
+      >
+        <div ref={scrollRef} className="flex-1 space-y-1 overflow-y-auto pr-1">
           {output.map((l, i) =>
             l.href ? (
               <a
@@ -207,14 +285,13 @@ export function TerminalRepl() {
                 key={i}
                 className={`whitespace-pre-wrap break-words ${TONE[l.tone ?? 'default']}`}
               >
-                {l.text || ' '}
+                {l.rich ? <RichLine text={l.text} /> : l.text || ' '}
               </div>
             ),
           )}
         </div>
 
-        {/* live input line */}
-        <div className="mt-1 flex items-center gap-2">
+        <div className="mt-1 flex items-center gap-2 border-t border-[#30363D] pt-2">
           <span className={TONE.accent}>❯</span>
           <input
             ref={inputRef}
@@ -226,14 +303,21 @@ export function TerminalRepl() {
             autoComplete="off"
             autoCapitalize="off"
             aria-label="terminal input"
-            placeholder={busy ? 'thinking…' : 'type a command — help'}
-            className="flex-1 bg-transparent text-[#E6EDF3] caret-[#2DD4BF] outline-none placeholder:text-[#8B949E]/60"
+            placeholder={busy ? 'thinking…' : 'type a command — help / man <cmd> / ask <質問>'}
+            className="min-w-0 flex-1 bg-transparent text-[#E6EDF3] caret-[#2DD4BF] outline-none placeholder:text-[#8B949E]/60"
           />
           {busy && <span className="inline-block h-4 w-2 animate-pulse bg-[#2DD4BF]" aria-hidden />}
         </div>
       </div>
 
-      {enabled && <div ref={containerRef} className="mt-2" />}
+      {/* Turnstile is kept off-screen — interaction-only, no visible widget here. */}
+      {enabled && (
+        <div
+          ref={containerRef}
+          aria-hidden
+          className="pointer-events-none fixed -left-[9999px] top-0"
+        />
+      )}
     </section>
   );
 }

--- a/app/src/components/terminal/TerminalSite.tsx
+++ b/app/src/components/terminal/TerminalSite.tsx
@@ -223,7 +223,7 @@ export function TerminalSite() {
 
         {/* skills */}
         <section id="skills" className="mt-10">
-          <SectionLabel>skills.json — AI を主軸に</SectionLabel>
+          <SectionLabel>skills.json — 技術スタック</SectionLabel>
           <div className="grid gap-3 md:grid-cols-2">
             {PROFILE.techStack.map((g) => (
               <div key={g.id} className="rounded-md border border-[#30363D] bg-[#161B22] p-4">

--- a/app/src/lib/terminal/commands.test.ts
+++ b/app/src/lib/terminal/commands.test.ts
@@ -62,4 +62,16 @@ describe('runCommand', () => {
   it('sudo is a friendly easter egg', () => {
     expect(flat('sudo rm -rf /')).toMatch(/sudoers/);
   });
+
+  it('man lists the manual and details a command', () => {
+    expect(flat('man')).toMatch(/ask/);
+    expect(flat('man ask')).toMatch(/USAGE/);
+    expect(run('man nope').lines[0]!.tone).toBe('error');
+  });
+
+  it('ls errors on an invalid argument (typo)', () => {
+    expect(run('ls projets/').lines[0]!.tone).toBe('error');
+    expect(flat('ls')).toContain('projects/');
+    expect(flat('ls projects/')).toContain('astralyx/');
+  });
 });

--- a/app/src/lib/terminal/commands.ts
+++ b/app/src/lib/terminal/commands.ts
@@ -15,6 +15,14 @@ export interface Line {
   text: string;
   tone?: Tone;
   href?: string;
+  /** Render through the assistant tokenizer (citations / urls become links). */
+  rich?: boolean;
+}
+
+export interface ManEntry {
+  name: string;
+  usage: string;
+  desc: string;
 }
 
 export type CmdAction =
@@ -35,26 +43,27 @@ export interface CmdCtx {
   activities: Activity[];
 }
 
-export const COMMANDS = [
-  'help',
-  'whoami',
-  'neofetch',
-  'ls',
-  'cat',
-  'projects',
-  'skills',
-  'activity',
-  'open',
-  'ask',
-  'chat',
-  'contact',
-  'social',
-  'editorial',
-  'clear',
-  'echo',
-  'sudo',
-  'cowsay',
-] as const;
+export const MANUAL: ManEntry[] = [
+  { name: 'help', usage: 'help', desc: 'コマンド一覧を表示' },
+  { name: 'man', usage: 'man [command]', desc: 'マニュアル（詳細）を表示' },
+  { name: 'whoami', usage: 'whoami', desc: 'プロフィールを1行で表示' },
+  { name: 'neofetch', usage: 'neofetch', desc: 'プロフィール＋アスキーアート' },
+  { name: 'ls', usage: 'ls [projects/]', desc: 'セクション/作品の一覧' },
+  { name: 'cat', usage: 'cat <file>', desc: 'mission.txt / contact.sh / projects/<id> を表示' },
+  { name: 'projects', usage: 'projects', desc: '作品一覧' },
+  { name: 'skills', usage: 'skills', desc: '技術スタックを表示' },
+  { name: 'activity', usage: 'activity', desc: 'タイムラインを表示' },
+  { name: 'open', usage: 'open <id>', desc: '作品のリンクを新規タブで開く' },
+  { name: 'ask', usage: 'ask <質問>', desc: 'AIクローンに質問し、回答をここにストリーミング' },
+  { name: 'chat', usage: 'chat', desc: 'クローンのチャットUIを開く' },
+  { name: 'contact', usage: 'contact', desc: '連絡先を表示' },
+  { name: 'social', usage: 'social', desc: 'X / GitHub / Kaggle' },
+  { name: 'editorial', usage: 'editorial', desc: 'エディトリアル表示へ切替' },
+  { name: 'clear', usage: 'clear', desc: '画面をクリア' },
+  { name: 'echo', usage: 'echo <text>', desc: 'テキストをそのまま表示' },
+];
+
+export const COMMANDS = [...MANUAL.map((m) => m.name), 'sudo', 'cowsay', 'matrix'] as const;
 
 const t = (text: string, tone?: Tone, href?: string): Line => ({ text, tone, href });
 
@@ -68,21 +77,11 @@ function workLine(w: Work): Line {
 
 function help(): Line[] {
   return [
-    t('Available commands:', 'muted'),
-    t('  help              このヘルプ'),
-    t('  whoami / neofetch プロフィール'),
-    t('  ls [projects/]    一覧'),
-    t('  cat <file>        mission.txt / contact.sh / projects/<id>'),
-    t('  projects          作品一覧'),
-    t('  skills            技術スタック'),
-    t('  activity          タイムライン'),
-    t('  open <id>         作品のリンクを開く'),
-    t('  ask <質問>        AIクローンに質問（回答をここに表示）', 'accent'),
-    t('  chat              クローンのチャットを開く'),
-    t('  contact / social  連絡先・SNS'),
-    t('  editorial         エディトリアル表示へ切替'),
-    t('  clear             画面クリア'),
-    t('  …ほかにも隠しコマンドが少々 😏', 'muted'),
+    t('Available commands ( man <command> で詳細・上の ▾ コマンド一覧でも確認可 ):', 'muted'),
+    ...MANUAL.map((m) =>
+      t(`  ${m.name.padEnd(10)} ${m.desc}`, m.name === 'ask' ? 'accent' : 'default'),
+    ),
+    t('  …ほかにも隠しコマンドが少々 😏 (sudo / cowsay / matrix)', 'muted'),
   ];
 }
 
@@ -119,6 +118,29 @@ export function runCommand(input: string, ctx: CmdCtx): CmdResult {
     case '?':
       return { lines: help() };
 
+    case 'man': {
+      if (!arg) {
+        return {
+          lines: [
+            t('MANUAL — man <command> で各コマンドの詳細を表示', 'muted'),
+            ...MANUAL.map((m) => t(`  ${m.name.padEnd(10)} ${m.usage.padEnd(16)} ${m.desc}`)),
+          ],
+        };
+      }
+      const e = MANUAL.find((m) => m.name === arg.toLowerCase());
+      if (!e) return { lines: [t(`man: ${arg}: マニュアルがありません`, 'error')] };
+      return {
+        lines: [
+          t('NAME', 'muted'),
+          t(`  ${e.name}`),
+          t('USAGE', 'muted'),
+          t(`  ${e.usage}`, 'accent'),
+          t('DESCRIPTION', 'muted'),
+          t(`  ${e.desc}`),
+        ],
+      };
+    }
+
     case 'whoami':
       return {
         lines: [
@@ -131,12 +153,15 @@ export function runCommand(input: string, ctx: CmdCtx): CmdResult {
       return { lines: neofetch(ctx) };
 
     case 'ls': {
+      if (!arg) {
+        return {
+          lines: [t('home.tsx  projects/  skills.json  activity.log  contact.sh', 'muted')],
+        };
+      }
       if (/^projects\/?$/.test(arg)) {
         return { lines: ctx.works.map((w) => t(`${w.id}/`, 'purple')) };
       }
-      return {
-        lines: [t('home.tsx  projects/  skills.json  activity.log  contact.sh', 'muted')],
-      };
+      return { lines: [t(`ls: ${arg}: No such directory`, 'error')] };
     }
 
     case 'projects':


### PR DESCRIPTION
- man コマンド＋MANUAL、▾ コマンド一覧プルダウン
- ls タイプミスをエラーに、Tab補完強化（ls/cat/open/man）
- ask 回答の引用/URL をクリック可能に、ask の Turnstile を画面外へ
- コンソールのテキストをコピー可能に（選択中はフォーカスを奪わない）
- コンソールを固定高さ＋入力行下部固定で見切れ/狭さ解消、skills.json 注記を技術スタックに
vitest 89 passed。