### PR TITLE
fix(ui): ヘッダーを両モードで sticky 固定＋REPLプロンプトを現在位置に

### DIFF
--- a/app/src/components/editorial/EditorialSite.tsx
+++ b/app/src/components/editorial/EditorialSite.tsx
@@ -33,7 +33,7 @@ export function EditorialSite() {
   const askClone = () => window.dispatchEvent(new CustomEvent('shiyow:open-chat'));
 
   return (
-    <div className="min-h-screen bg-surface text-on-surface">
+    <div className="min-h-screen overflow-x-clip bg-surface text-on-surface">
       <a
         href="#top"
         className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[110] focus:bg-on-surface focus:text-surface focus:px-4 focus:py-2 focus:font-mono focus:text-xs focus:uppercase focus:tracking-widest"

--- a/app/src/components/terminal/TerminalRepl.tsx
+++ b/app/src/components/terminal/TerminalRepl.tsx
@@ -265,33 +265,30 @@ export function TerminalRepl() {
       )}
 
       <div
+        ref={scrollRef}
         onClick={focusUnlessSelecting}
-        className="flex h-[clamp(300px,46vh,480px)] select-text flex-col rounded-md bg-[#0D1117]"
+        className="h-[clamp(300px,46vh,480px)] select-text space-y-1 overflow-y-auto rounded-md bg-[#0D1117] pr-1"
       >
-        <div ref={scrollRef} className="flex-1 space-y-1 overflow-y-auto pr-1">
-          {output.map((l, i) =>
-            l.href ? (
-              <a
-                key={i}
-                href={l.href}
-                target="_blank"
-                rel="noreferrer"
-                className={`block whitespace-pre-wrap break-words ${TONE.accent} hover:underline`}
-              >
-                {l.text}
-              </a>
-            ) : (
-              <div
-                key={i}
-                className={`whitespace-pre-wrap break-words ${TONE[l.tone ?? 'default']}`}
-              >
-                {l.rich ? <RichLine text={l.text} /> : l.text || ' '}
-              </div>
-            ),
-          )}
-        </div>
+        {output.map((l, i) =>
+          l.href ? (
+            <a
+              key={i}
+              href={l.href}
+              target="_blank"
+              rel="noreferrer"
+              className={`block whitespace-pre-wrap break-words ${TONE.accent} hover:underline`}
+            >
+              {l.text}
+            </a>
+          ) : (
+            <div key={i} className={`whitespace-pre-wrap break-words ${TONE[l.tone ?? 'default']}`}>
+              {l.rich ? <RichLine text={l.text} /> : l.text || ' '}
+            </div>
+          ),
+        )}
 
-        <div className="mt-1 flex items-center gap-2 border-t border-[#30363D] pt-2">
+        {/* prompt follows the last line — like a real shell */}
+        <div className="flex items-center gap-2">
           <span className={TONE.accent}>❯</span>
           <input
             ref={inputRef}

--- a/app/src/components/terminal/TerminalSite.tsx
+++ b/app/src/components/terminal/TerminalSite.tsx
@@ -90,7 +90,7 @@ export function TerminalSite() {
   }, [menuOpen]);
 
   return (
-    <div className="min-h-screen bg-[#0D1117] pb-12 font-mono text-[14px] text-[#E6EDF3] selection:bg-[#2DD4BF]/30">
+    <div className="min-h-screen overflow-x-clip bg-[#0D1117] pb-12 font-mono text-[14px] text-[#E6EDF3] selection:bg-[#2DD4BF]/30">
       <a
         href="#terminal-top"
         className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[110] focus:bg-[#2DD4BF] focus:px-4 focus:py-2 focus:text-[12px] focus:text-[#0D1117]"

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -74,7 +74,9 @@ body {
   background-color: var(--color-surface);
   color: var(--color-on-surface);
   font-family: var(--font-body);
-  overflow-x: hidden;
+  /* NOTE: do NOT set overflow-x:hidden here — it makes <body> a scroll container
+     and breaks `position: sticky` headers. Horizontal overflow is clipped on the
+     site root wrappers with `overflow-x: clip` (which does not break sticky). */
 }
 
 body {


### PR DESCRIPTION
- html/body の overflow-x:hidden が sticky を壊していたため撤去、横スクロール防止は overflow-x:clip をルートに移設 → 両モードでヘッダー固定（検証: scroll 後も header top=0、横溢れ 0）
- REPL のプロンプトを下部固定 → 出力直後（現在位置）に（実シェル同様）