### PR TITLE
fix(ui): モバイルで view 切替トグルの改行を修正

### DIFF
--- a/app/src/components/editorial/EditorialNav.tsx
+++ b/app/src/components/editorial/EditorialNav.tsx
@@ -92,7 +92,7 @@ export function EditorialNav() {
               <span className="hidden font-mono text-[10px] uppercase tracking-widest text-on-surface-variant sm:inline">
                 View
               </span>
-              <div className="flex items-center border-2 border-on-surface font-mono text-[11px] uppercase tracking-widest">
+              <div className="flex shrink-0 items-center whitespace-nowrap border-2 border-on-surface font-mono text-[11px] uppercase tracking-widest">
                 <span aria-current="true" className="bg-on-surface px-2.5 py-1.5 text-surface">
                   Editorial
                 </span>
@@ -100,7 +100,7 @@ export function EditorialNav() {
                   type="button"
                   onClick={() => setMode('terminal')}
                   aria-label="Switch to terminal mode"
-                  className="px-2.5 py-1.5 hover:bg-on-surface/10"
+                  className="whitespace-nowrap px-2.5 py-1.5 hover:bg-on-surface/10"
                 >
                   {'>_'} Terminal
                 </button>

--- a/app/src/components/terminal/TerminalSite.tsx
+++ b/app/src/components/terminal/TerminalSite.tsx
@@ -120,20 +120,23 @@ export function TerminalSite() {
               onClick={toggleFullscreen}
             />
           </div>
-          <span className={`ml-3 truncate text-[12px] ${MUTED}`}>
+          <span className={`ml-3 min-w-0 truncate text-[12px] ${MUTED}`}>
             shiyow@devstation: ~/shiyow.dev — bash
           </span>
-          <div className="ml-auto flex items-center gap-2">
-            <div className="flex items-center overflow-hidden rounded-md border border-[#30363D] text-[12px]">
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            <div className="flex shrink-0 items-center overflow-hidden whitespace-nowrap rounded-md border border-[#30363D] text-[12px]">
               <button
                 type="button"
                 onClick={() => setMode('editorial')}
                 aria-label="Switch to editorial mode"
-                className="px-2.5 py-1 text-[#8B949E] hover:text-[#E6EDF3]"
+                className="whitespace-nowrap px-2.5 py-1 text-[#8B949E] hover:text-[#E6EDF3]"
               >
                 ◧ editorial
               </button>
-              <span aria-current="true" className="bg-[#2DD4BF] px-2.5 py-1 text-[#0D1117]">
+              <span
+                aria-current="true"
+                className="whitespace-nowrap bg-[#2DD4BF] px-2.5 py-1 text-[#0D1117]"
+              >
                 terminal
               </span>
             </div>


### PR DESCRIPTION
terminal/editorial 両ヘッダーのトグルがモバイルでアイコンと文字に改行されていた問題を修正（whitespace-nowrap＋shrink-0、タイトルを min-w-0 で truncate）。両モード 375px で1行に収まることを確認。