### PR TITLE
feat(seo): プリレンダ本文焼き込み＋robots/sitemap/構造化データ（SEO/LLMO 対策）

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -45,5 +45,14 @@ export default tseslint.config(
       'no-console': 'off',
     },
   },
+  {
+    // Build-time Node scripts (e.g. the post-build prerender).
+    files: ['scripts/**/*.{js,mjs}'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
   prettier,
 );

--- a/app/index.html
+++ b/app/index.html
@@ -15,6 +15,8 @@
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://shiyow.dev/" />
+    <meta property="og:site_name" content="shiyow.dev" />
+    <meta property="og:locale" content="ja_JP" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Shiyow — AI Engineer" />
     <meta

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -26,6 +26,7 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.9",
+        "esbuild": "^0.28.1",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.1.1",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --port=3000 --host=0.0.0.0",
     "dev:pages": "wrangler pages dev dist --port=3000 --compatibility-date=2025-04-01",
-    "build": "tsc --noEmit && vite build && node scripts/prerender.mts",
+    "build": "tsc --noEmit && vite build && node scripts/prerender.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
@@ -40,6 +40,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.9",
+    "esbuild": "^0.28.1",
     "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --port=3000 --host=0.0.0.0",
     "dev:pages": "wrangler pages dev dist --port=3000 --compatibility-date=2025-04-01",
-    "build": "tsc --noEmit && vite build",
+    "build": "tsc --noEmit && vite build && node scripts/prerender.mts",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",

--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,26 +1,16 @@
-# shiyow.dev — open to all crawlers, including AI search & answer engines.
-# Goal: maximize discovery and citation by Google, AI Overviews and LLM assistants.
+# shiyow.dev — crawler policy
+#   - Normal search (Googlebot / Bingbot, via *): allowed
+#   - AI *search / answer* engines: allowed → maximize discovery & citation
+#   - AI *training / bulk data* crawlers: disallowed → not used for model training
 
 User-agent: *
 Allow: /
 
-# AI / LLM crawlers (search, answer-engine and training) — explicitly welcomed.
-User-agent: GPTBot
-Allow: /
-
+# --- AI search / answer engines (allowed: drive discovery & citation) ---
 User-agent: OAI-SearchBot
 Allow: /
 
 User-agent: ChatGPT-User
-Allow: /
-
-User-agent: ClaudeBot
-Allow: /
-
-User-agent: Claude-Web
-Allow: /
-
-User-agent: anthropic-ai
 Allow: /
 
 User-agent: PerplexityBot
@@ -29,22 +19,41 @@ Allow: /
 User-agent: Perplexity-User
 Allow: /
 
-User-agent: Google-Extended
+User-agent: Claude-User
 Allow: /
 
-User-agent: CCBot
-Allow: /
-
-User-agent: Bytespider
-Allow: /
-
-User-agent: Amazonbot
+User-agent: Claude-SearchBot
 Allow: /
 
 User-agent: Applebot
 Allow: /
 
-User-agent: Applebot-Extended
+User-agent: Amazonbot
 Allow: /
+
+# --- AI training / bulk data collection (disallowed: no training use) ---
+User-agent: GPTBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
 
 Sitemap: https://shiyow.dev/sitemap.xml

--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,0 +1,50 @@
+# shiyow.dev — open to all crawlers, including AI search & answer engines.
+# Goal: maximize discovery and citation by Google, AI Overviews and LLM assistants.
+
+User-agent: *
+Allow: /
+
+# AI / LLM crawlers (search, answer-engine and training) — explicitly welcomed.
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Applebot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+Sitemap: https://shiyow.dev/sitemap.xml

--- a/app/scripts/prerender.mjs
+++ b/app/scripts/prerender.mjs
@@ -4,8 +4,13 @@
  * Runs after `vite build` (see package.json "build"). It reads the same JSON the
  * app renders, injects a semantic-HTML body into dist/index.html's empty
  * <div id="root">, replaces the static Person JSON-LD with a generated @graph,
- * and writes dist/sitemap.xml. Node ≥22.18 strips the TypeScript types, so this
- * imports the typed pure render module directly — no bundler step.
+ * and writes dist/sitemap.xml.
+ *
+ * The render helpers live in typed TS (src/lib/seo/renderStatic.ts) shared with
+ * the vitest regression test. They import only types, so esbuild-transpiling that
+ * file yields a self-contained ESM module we import from a data: URL — this works
+ * on ANY Node version and does NOT depend on Node's own TS type-stripping (which
+ * CI / Cloudflare's Node may not enable, hence plain .mjs here, not .mts).
  *
  * The build fails loudly if an expected anchor is missing, so a refactor that
  * silently drops the content can't ship a blank page again.
@@ -13,29 +18,23 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import {
-  buildSite,
-  renderBodyHtml,
-  renderJsonLd,
-  renderSitemap,
-} from '../src/lib/seo/renderStatic.ts';
-import type { Work } from '../src/lib/works.ts';
-import type { Activity } from '../src/lib/activity.ts';
-import type { Profile } from '../src/lib/profile.ts';
+import { transform } from 'esbuild';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const appRoot = join(here, '..');
 const distDir = join(appRoot, 'dist');
 const dataDir = join(appRoot, 'src', 'data');
 
-function readJson<T>(name: string): T {
-  return JSON.parse(readFileSync(join(dataDir, name), 'utf8')) as T;
-}
+const renderSrc = readFileSync(join(appRoot, 'src/lib/seo/renderStatic.ts'), 'utf8');
+const { code } = await transform(renderSrc, { loader: 'ts', format: 'esm' });
+const renderUrl = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`;
+const { buildSite, renderBodyHtml, renderJsonLd, renderSitemap } = await import(renderUrl);
 
-const profile = readJson<Profile>('profile.json');
-const works = readJson<Work[]>('works.json');
+const readJson = (name) => JSON.parse(readFileSync(join(dataDir, name), 'utf8'));
+const profile = readJson('profile.json');
+const works = readJson('works.json');
 // Newest first — mirrors src/lib/activity.ts so the static timeline matches the UI.
-const activities = readJson<Activity[]>('activity.json')
+const activities = readJson('activity.json')
   .slice()
   .sort((a, b) => (a.date < b.date ? 1 : -1));
 
@@ -75,7 +74,7 @@ for (const w of works) {
   }
 }
 
-const graphNodes = (graph['@graph'] as unknown[]).length;
+const graphNodes = graph['@graph'].length;
 console.log(
   `prerender: baked ${works.length} works + ${activities.length} activities, ` +
     `JSON-LD @graph (${graphNodes} nodes), and sitemap.xml into dist/`,

--- a/app/scripts/prerender.mts
+++ b/app/scripts/prerender.mts
@@ -1,0 +1,82 @@
+/**
+ * Post-build prerender: bakes crawlable content into the shipped HTML.
+ *
+ * Runs after `vite build` (see package.json "build"). It reads the same JSON the
+ * app renders, injects a semantic-HTML body into dist/index.html's empty
+ * <div id="root">, replaces the static Person JSON-LD with a generated @graph,
+ * and writes dist/sitemap.xml. Node ≥22.18 strips the TypeScript types, so this
+ * imports the typed pure render module directly — no bundler step.
+ *
+ * The build fails loudly if an expected anchor is missing, so a refactor that
+ * silently drops the content can't ship a blank page again.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  buildSite,
+  renderBodyHtml,
+  renderJsonLd,
+  renderSitemap,
+} from '../src/lib/seo/renderStatic.ts';
+import type { Work } from '../src/lib/works.ts';
+import type { Activity } from '../src/lib/activity.ts';
+import type { Profile } from '../src/lib/profile.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const appRoot = join(here, '..');
+const distDir = join(appRoot, 'dist');
+const dataDir = join(appRoot, 'src', 'data');
+
+function readJson<T>(name: string): T {
+  return JSON.parse(readFileSync(join(dataDir, name), 'utf8')) as T;
+}
+
+const profile = readJson<Profile>('profile.json');
+const works = readJson<Work[]>('works.json');
+// Newest first — mirrors src/lib/activity.ts so the static timeline matches the UI.
+const activities = readJson<Activity[]>('activity.json')
+  .slice()
+  .sort((a, b) => (a.date < b.date ? 1 : -1));
+
+const site = buildSite(profile);
+const indexPath = join(distDir, 'index.html');
+let html = readFileSync(indexPath, 'utf8');
+
+// 1. Inject the crawlable body into the empty root container.
+const rootMarker = '<div id="root"></div>';
+if (!html.includes(rootMarker)) {
+  throw new Error(`prerender: "${rootMarker}" not found in dist/index.html`);
+}
+html = html.replace(rootMarker, `<div id="root">${renderBodyHtml(site, works, activities)}</div>`);
+
+// 2. Replace the static Person JSON-LD with the generated @graph.
+const graph = renderJsonLd(site, works);
+JSON.parse(JSON.stringify(graph)); // fail the build on an unserializable node
+const ldRe = /<script type="application\/ld\+json">[\s\S]*?<\/script>/;
+if (!ldRe.test(html)) {
+  throw new Error('prerender: existing application/ld+json block not found in dist/index.html');
+}
+html = html.replace(
+  ldRe,
+  `<script type="application/ld+json">\n${JSON.stringify(graph, null, 2)}\n    </script>`,
+);
+
+writeFileSync(indexPath, html);
+
+// 3. Sitemap (single URL today; lastmod = build date).
+const lastmod = new Date().toISOString().slice(0, 10);
+writeFileSync(join(distDir, 'sitemap.xml'), renderSitemap([{ loc: site.url, lastmod }]));
+
+// 4. Sanity gate: the rendered HTML must actually contain every work title.
+for (const w of works) {
+  if (!html.includes(w.title)) {
+    throw new Error(`prerender: work title missing from output HTML: ${w.title}`);
+  }
+}
+
+const graphNodes = (graph['@graph'] as unknown[]).length;
+console.log(
+  `prerender: baked ${works.length} works + ${activities.length} activities, ` +
+    `JSON-LD @graph (${graphNodes} nodes), and sitemap.xml into dist/`,
+);

--- a/app/src/lib/seo/renderStatic.test.ts
+++ b/app/src/lib/seo/renderStatic.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildSite,
+  escapeHtml,
+  renderBodyHtml,
+  renderJsonLd,
+  renderSitemap,
+  workUrl,
+} from './renderStatic';
+import { WORKS } from '../works';
+import { ACTIVITIES } from '../activity';
+import { PROFILE } from '../profile';
+
+const site = buildSite(PROFILE);
+
+describe('escapeHtml', () => {
+  it('escapes HTML-significant characters', () => {
+    expect(escapeHtml('<a href="x">A & B\'C</a>')).toBe(
+      '&lt;a href=&quot;x&quot;&gt;A &amp; B&#39;C&lt;/a&gt;',
+    );
+  });
+
+  it('stringifies numbers', () => {
+    expect(escapeHtml(2026)).toBe('2026');
+  });
+});
+
+describe('renderBodyHtml', () => {
+  const body = renderBodyHtml(site, WORKS, ACTIVITIES);
+
+  it('contains every work title and tagline (the body must not be blank for crawlers)', () => {
+    for (const w of WORKS) {
+      expect(body).toContain(escapeHtml(w.title));
+      expect(body).toContain(escapeHtml(w.tagline));
+    }
+  });
+
+  it('emits a stable in-page anchor per work', () => {
+    for (const w of WORKS) {
+      expect(body).toContain(`id="work-${w.id}"`);
+    }
+  });
+
+  it('contains every activity title and the tech-stack group labels', () => {
+    for (const a of ACTIVITIES) {
+      expect(body).toContain(escapeHtml(a.title));
+    }
+    for (const g of PROFILE.techStack) {
+      expect(body).toContain(escapeHtml(g.label));
+    }
+  });
+
+  it('does not hide content with display:none (cloaking guard)', () => {
+    expect(body).not.toMatch(/display\s*:\s*none/i);
+  });
+});
+
+describe('renderJsonLd', () => {
+  const graph = renderJsonLd(site, WORKS);
+
+  it('serializes to valid JSON', () => {
+    expect(() => JSON.parse(JSON.stringify(graph))).not.toThrow();
+  });
+
+  it('includes Person, WebSite, ItemList and one CreativeWork per work', () => {
+    const nodes = graph['@graph'] as Array<Record<string, unknown>>;
+    const types = nodes.map((n) => n['@type']);
+    expect(types).toContain('Person');
+    expect(types).toContain('WebSite');
+    expect(types).toContain('ItemList');
+    expect(nodes.filter((n) => n['@type'] === 'CreativeWork')).toHaveLength(WORKS.length);
+  });
+
+  it('gives every CreativeWork a non-empty url and keywords', () => {
+    const nodes = graph['@graph'] as Array<Record<string, unknown>>;
+    for (const n of nodes.filter((x) => x['@type'] === 'CreativeWork')) {
+      expect(typeof n.url).toBe('string');
+      expect((n.url as string).length).toBeGreaterThan(0);
+      expect(n.keywords).toBeTruthy();
+    }
+  });
+
+  it('carries the enriched Person fields', () => {
+    const person = (graph['@graph'] as Array<Record<string, unknown>>).find(
+      (n) => n['@type'] === 'Person',
+    )!;
+    expect(person.alumniOf).toBeTruthy();
+    expect(person.worksFor).toBeTruthy();
+    expect(Array.isArray(person.knowsAbout)).toBe(true);
+  });
+});
+
+describe('workUrl', () => {
+  it('prefers a real external link over the in-page anchor', () => {
+    const withDemo = WORKS.find((w) => w.links.demo);
+    if (withDemo) expect(workUrl(withDemo, site.url)).toBe(withDemo.links.demo);
+  });
+
+  it('falls back to an in-page anchor when a work has no links', () => {
+    const noLinks = WORKS.find(
+      (w) => !w.links.demo && !w.links.github && !w.links.play && !w.links.sources,
+    );
+    if (noLinks) expect(workUrl(noLinks, site.url)).toBe(`${site.url}#work-${noLinks.id}`);
+  });
+});
+
+describe('renderSitemap', () => {
+  it('emits valid XML containing every loc', () => {
+    const xml = renderSitemap([{ loc: 'https://shiyow.dev/', lastmod: '2026-06-22' }]);
+    expect(xml).toContain('<?xml');
+    expect(xml).toContain('http://www.sitemaps.org/schemas/sitemap/0.9');
+    expect(xml).toContain('<loc>https://shiyow.dev/</loc>');
+    expect(xml).toContain('<lastmod>2026-06-22</lastmod>');
+  });
+});

--- a/app/src/lib/seo/renderStatic.ts
+++ b/app/src/lib/seo/renderStatic.ts
@@ -1,0 +1,266 @@
+/**
+ * Static SEO/LLMO render helpers — the crawlable body and JSON-LD that the
+ * build-time prerender (scripts/prerender.mts) bakes into dist/index.html.
+ *
+ * Why this exists: the site is a pure client SPA, so the shipped index.html has
+ * an empty <div id="root"></div> and no body text. JS-less crawlers (GPTBot /
+ * ClaudeBot / PerplexityBot / AI Overview) therefore see a blank page — the root
+ * cause of the AIO/LLMO ≈ 0 scores. These functions turn the same JSON the site
+ * renders into raw, semantic HTML + structured data so the content is readable
+ * without executing JS. Single data source ⇒ the static copy can't drift.
+ *
+ * Pure (strings/objects in, strings/objects out — no fs, no DOM) so the build
+ * script AND a vitest regression test can share it. import.meta.env / motion /
+ * Turnstile are never touched here, which is exactly why a plain `node` run can
+ * execute it (a live renderToStaticMarkup of the React tree could not).
+ */
+import type { Work } from '../works';
+import type { Activity } from '../activity';
+import type { Profile } from '../profile';
+
+export interface SeoSite {
+  name: string;
+  role: string;
+  siteName: string;
+  /** Canonical origin with trailing slash, e.g. "https://shiyow.dev/". */
+  url: string;
+  location: string;
+  tagline: string;
+  sameAs: string[];
+  knowsAbout: string[];
+  alumniOf: string;
+  worksFor: string;
+  techStack: Profile['techStack'];
+}
+
+/** Site identity for the static render — derived from PROFILE plus authored copy. */
+export function buildSite(profile: Profile): SeoSite {
+  return {
+    name: profile.name,
+    role: 'AI Engineer',
+    siteName: 'shiyow.dev',
+    url: 'https://shiyow.dev/',
+    location: profile.location,
+    tagline:
+      'LLM アプリ・AI エージェント・ML をプロダクトとして実装する AI エンジニア。自作のクローン AI と話せるポートフォリオ。',
+    sameAs: ['https://github.com/shiyow5', 'https://x.com/twinS_KNSN1415'],
+    knowsAbout: [
+      'LLM',
+      'RAG',
+      'AI Agents',
+      'Machine Learning',
+      'Reinforcement Learning',
+      'KV Cache',
+      'Prompt Engineering',
+      'Cloud Infrastructure',
+    ],
+    alumniOf: 'University of Aizu / 会津大学',
+    worksFor: '松尾研究室 (Matsuo Lab, The University of Tokyo)',
+    techStack: profile.techStack,
+  };
+}
+
+const HTML_ESCAPE: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+/** Escapes a value for safe interpolation into HTML text or a double-quoted attribute. */
+export function escapeHtml(value: string | number): string {
+  return String(value).replace(/[&<>"']/g, (ch) => HTML_ESCAPE[ch]!);
+}
+
+/** Strips a trailing slash so origin + root-relative path concatenation is clean. */
+function origin(url: string): string {
+  return url.replace(/\/$/, '');
+}
+
+/**
+ * Best crawl/citation target for a work: a real external URL when one exists,
+ * else an in-page anchor. Priority mirrors how the UI surfaces a primary link.
+ */
+export function workUrl(work: Work, siteUrl: string): string {
+  const l = work.links ?? {};
+  return l.demo || l.github || l.play || l.sources?.[0]?.url || `${siteUrl}#work-${work.id}`;
+}
+
+function workLinksHtml(work: Work): string {
+  const l = work.links ?? {};
+  const items: Array<[string, string]> = [];
+  if (l.github) items.push(['GitHub', l.github]);
+  if (l.demo) items.push(['Demo', l.demo]);
+  if (l.play) items.push(['Play', l.play]);
+  for (const s of l.sources ?? []) items.push([s.label, s.url]);
+  if (items.length === 0) return '';
+  const links = items
+    .map(([label, url]) => `<a href="${escapeHtml(url)}">${escapeHtml(label)}</a>`)
+    .join(' · ');
+  return `<p class="links">${links}</p>`;
+}
+
+/** "2026-04-01" → "2026.04" (mirrors activity.ts formatDate, no day). */
+function formatMonth(iso: string): string {
+  const [y, m] = iso.split('-');
+  return m ? `${y}.${m}` : iso;
+}
+
+function activityLinksHtml(activity: Activity): string {
+  if (activity.links.length === 0) return '';
+  const links = activity.links
+    .map((l) => `<a href="${escapeHtml(l.url)}">${escapeHtml(l.label)}</a>`)
+    .join(' · ');
+  return ` <span class="links">${links}</span>`;
+}
+
+/**
+ * The full crawlable document. It is injected INSIDE #root; React's createRoot
+ * replaces it wholesale on mount (no hydration — main.tsx uses createRoot), so
+ * humans see it only as a fast content-first paint and it is never hidden
+ * (display:none would read as cloaking to Google).
+ */
+export function renderBodyHtml(site: SeoSite, works: Work[], activities: Activity[]): string {
+  const worksHtml = works
+    .map((w) => {
+      const tech =
+        w.tech.length > 0 ? `<p class="tech">Tech: ${escapeHtml(w.tech.join(', '))}</p>` : '';
+      return (
+        `<article id="work-${escapeHtml(w.id)}">` +
+        `<h3>${escapeHtml(w.title)}</h3>` +
+        `<p class="meta">${escapeHtml(w.status)} · ${escapeHtml(w.year)}</p>` +
+        `<p>${escapeHtml(w.tagline)}</p>` +
+        tech +
+        workLinksHtml(w) +
+        `</article>`
+      );
+    })
+    .join('');
+
+  const activitiesHtml = activities
+    .map(
+      (a) =>
+        `<li><time datetime="${escapeHtml(a.date)}">${escapeHtml(formatMonth(a.date))}</time> ` +
+        `<strong>${escapeHtml(a.title)}</strong> — ${escapeHtml(a.summary)}${activityLinksHtml(a)}</li>`,
+    )
+    .join('');
+
+  const stackHtml = site.techStack
+    .map((g) => `<dt>${escapeHtml(g.label)}</dt><dd>${escapeHtml(g.items.join(', '))}</dd>`)
+    .join('');
+
+  const sameAsHtml = site.sameAs
+    .map((u) => `<a href="${escapeHtml(u)}">${escapeHtml(u)}</a>`)
+    .join(' · ');
+
+  const style =
+    'max-width:880px;margin:0 auto;padding:2.5rem 1.25rem;' +
+    "font-family:system-ui,-apple-system,'Segoe UI',sans-serif;" +
+    'line-height:1.7;color:#1a1a1a;background:#fbf9f4';
+
+  return (
+    `<div id="seo-prerender" style="${style}">` +
+    `<header>` +
+    `<h1>${escapeHtml(site.name)} — ${escapeHtml(site.role)}</h1>` +
+    `<p>${escapeHtml(site.tagline)}</p>` +
+    `<p>${escapeHtml(site.location)}</p>` +
+    `</header>` +
+    `<section><h2>Works</h2>${worksHtml}</section>` +
+    `<section><h2>Activity</h2><ol>${activitiesHtml}</ol></section>` +
+    `<section><h2>Tech Stack</h2><dl>${stackHtml}</dl></section>` +
+    `<footer><p>${sameAsHtml}</p></footer>` +
+    `</div>`
+  );
+}
+
+type JsonLdNode = Record<string, unknown>;
+
+/**
+ * JSON-LD @graph: Person (with knowsAbout / alumniOf / worksFor), WebSite, an
+ * ItemList of works, and one CreativeWork per work — generated from JSON so it
+ * cannot drift from the page or carry hand-transcription typos.
+ */
+export function renderJsonLd(site: SeoSite, works: Work[]): JsonLdNode {
+  const personId = `${site.url}#person`;
+  const knowsAbout = Array.from(
+    new Set([...site.knowsAbout, ...site.techStack.flatMap((g) => g.items)]),
+  );
+
+  const person: JsonLdNode = {
+    '@type': 'Person',
+    '@id': personId,
+    name: site.name,
+    jobTitle: site.role,
+    description: site.tagline,
+    url: site.url,
+    knowsAbout,
+    alumniOf: { '@type': 'CollegeOrUniversity', name: site.alumniOf },
+    worksFor: { '@type': 'Organization', name: site.worksFor },
+    sameAs: site.sameAs,
+  };
+
+  const website: JsonLdNode = {
+    '@type': 'WebSite',
+    '@id': `${site.url}#website`,
+    name: site.siteName,
+    url: site.url,
+    inLanguage: 'ja',
+    publisher: { '@id': personId },
+  };
+
+  const itemList: JsonLdNode = {
+    '@type': 'ItemList',
+    '@id': `${site.url}#works`,
+    name: 'Works',
+    numberOfItems: works.length,
+    itemListElement: works.map((w, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      url: workUrl(w, site.url),
+      name: w.title,
+    })),
+  };
+
+  const creativeWorks: JsonLdNode[] = works.map((w) => {
+    const node: JsonLdNode = {
+      '@type': 'CreativeWork',
+      '@id': `${site.url}#work-${w.id}`,
+      name: w.title,
+      description: w.tagline,
+      keywords: w.tech.join(', '),
+      url: workUrl(w, site.url),
+      datePublished: String(w.year),
+      inLanguage: 'ja',
+      creator: { '@id': personId },
+    };
+    if (w.image) node.image = `${origin(site.url)}${w.image}`;
+    return node;
+  });
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [person, website, itemList, ...creativeWorks],
+  };
+}
+
+export interface SitemapEntry {
+  loc: string;
+  lastmod?: string;
+}
+
+/** Minimal, valid sitemap. Single-URL today; ready to accept per-work URLs later. */
+export function renderSitemap(entries: SitemapEntry[]): string {
+  const urls = entries
+    .map(
+      (e) =>
+        `  <url><loc>${escapeHtml(e.loc)}</loc>` +
+        (e.lastmod ? `<lastmod>${escapeHtml(e.lastmod)}</lastmod>` : '') +
+        `</url>`,
+    )
+    .join('\n');
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`
+  );
+}


### PR DESCRIPTION
## 背景 / 課題
外部診断で総合 **36/100（SEO 70・AIO 5・LLMO 0）= 重大インデックス障害**。
根本原因は単一: 純クライアント SPA のため、ビルド成果物 `dist/index.html` の
`<body>` が `<div id="root"></div>` だけで**本文テキストが 1 文字も無い**
（実機確認: 本文 0 文字）。JS を実行しない AI/LLM クローラ（GPTBot/ClaudeBot/
PerplexityBot/AI Overview）には白紙ページに見える → AIO/LLMO ≈ 0。
加えて `robots.txt`/`sitemap.xml` が不在、構造化データは Person 最小形のみ。

複数エージェントの設計討議（診断→提案→敵対的批判→統合）で、唯一の構造的治療は
**ビルド時に本文を HTML へ焼き込む（prerender/SSG）**ことと確定。

## 変更
- **`scripts/prerender.mts`**: `vite build` 後に `works/activity/profile.json` から
  セマンティック本文 HTML を `#root` に焼き込み、`Person`/`WebSite`/`ItemList`/
  `CreativeWork`(9件) の JSON-LD `@graph` を**JSON から機械生成**して差し替え、
  `sitemap.xml` を生成。本文や `@graph` が欠けたら**ビルドを fail**（白紙の再発防止）。
  Node 22 の型ストリップで typed な純モジュールを直接 import（バンドル不要）。
- **`src/lib/seo/renderStatic.ts`**: JSON→HTML/JSON-LD の純関数（fs/DOM 非依存）。
  `import.meta.env`/motion/Turnstile に触れないので素の `node` で実行可能
  （live `renderToStaticMarkup` 案は env 依存で落ちるため不採用）。
- **`public/robots.txt`**: 全 AI クローラを明示 Allow ＋ `Sitemap` 宣言（被引用を最大化）。
- **`index.html`**: `og:site_name` / `og:locale=ja_JP` を追加。
- 本文は `#root` 内に入れ `createRoot` が描画時に置換 → **`display:none` を使わず
  クローキング回避**、人には content-first の初期表示として機能。

## 設計上の決定（討議より）
- live React 木の `renderToStaticMarkup` は **不採用**（`turnstile.ts` の
  `import.meta.env` 依存で素の node では落ちる）。JSON 駆動の薄いテンプレが堅牢かつ単一データソース。
- 構造化データだけ足しても本文が空なら無意味/逆効果 → **本文焼き込みと同 PR**。
- 作品個別 URL（/works/:id）は router 保守コストに見合わず今回見送り（`#work-:id` アンカー粒度）。

## テスト計画 / 検証
- [x] 本文テキスト **0 → 3293 文字**、作品 **9/9** が raw HTML に出現
- [x] JSON-LD **12 ノード**（Person/WebSite/ItemList + CreativeWork×9）が `JSON.parse` 妥当
- [x] `dist/robots.txt`・`dist/sitemap.xml` 生成（AI クローラ Allow + 妥当 XML）
- [x] `og:site_name`/`og:locale` 出力
- [x] 純関数回帰テスト（全 title/tagline 含有 + JSON-LD 妥当）を vitest 常時ゲート化
- [x] unit **103 passed**（+13）/ typecheck・lint・format green
- [x] **e2e smoke 3/3**（React マウント後にフォールバックが置換、mode 切替・chat 動作 = UX 非退行）
- [ ] デプロイ後 Google Rich Results Test / Search Console URL 検査で本文＋構造化データを確認