### PR TITLE
fix(chat): 502 をグレースフル化＋Turnstile トークンをエラー時もリフレッシュ

### DIFF
--- a/app/functions/api/chat.ts
+++ b/app/functions/api/chat.ts
@@ -241,26 +241,42 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   // it where supported (older models reject thinkingConfig).
   const supportsThinking = /2\.5|latest/.test(model);
 
-  const upstream = await fetch(url, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({
-      systemInstruction: { parts: [{ text: buildSystemInstruction(nonce) }] },
-      contents: buildGeminiContents(messages, nonce),
-      generationConfig: {
-        maxOutputTokens: MAX_OUTPUT_TOKENS,
-        temperature: 0.7,
-        topP: 0.9,
-        ...(supportsThinking ? { thinkingConfig: { thinkingBudget: 0 } } : {}),
+  // The upstream call can THROW (network error, edge subrequest timeout) — not
+  // just return non-ok. An unhandled throw here surfaces to the visitor as a bare
+  // "HTTP 502" (Cloudflare's HTML error page, no JSON), so catch it and return a
+  // friendly, parseable error the client can render.
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        systemInstruction: { parts: [{ text: buildSystemInstruction(nonce) }] },
+        contents: buildGeminiContents(messages, nonce),
+        generationConfig: {
+          maxOutputTokens: MAX_OUTPUT_TOKENS,
+          temperature: 0.7,
+          topP: 0.9,
+          ...(supportsThinking ? { thinkingConfig: { thinkingBudget: 0 } } : {}),
+        },
+        safetySettings: [
+          { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+          { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+          { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+          { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
+        ],
+      }),
+    });
+  } catch (err) {
+    return json(
+      {
+        error: 'AI への接続でエラーが発生しました。少し時間をおいて再度お試しください。',
+        code: 'upstream_unreachable',
+        detail: ((err as Error)?.message ?? 'fetch failed').slice(0, 200),
       },
-      safetySettings: [
-        { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
-        { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
-        { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
-        { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_MEDIUM_AND_ABOVE' },
-      ],
-    }),
-  });
+      { status: 502 },
+    );
+  }
 
   if (!upstream.ok || !upstream.body) {
     const detail = await upstream.text().catch(() => '');

--- a/app/src/components/chat/ChatWidget.tsx
+++ b/app/src/components/chat/ChatWidget.tsx
@@ -226,6 +226,11 @@ export function ChatWidget() {
           ),
         );
         setSending(false);
+        // The server consumes the single-use Turnstile token during verification
+        // (even when the request later fails), so a stale token would make the
+        // NEXT message fail with "turnstile verification failed". Refresh it here
+        // too, not just on success.
+        reset();
       },
     });
   };


### PR DESCRIPTION
## 症状（本番）
クローンチャットで 1 通目 → **⚠ HTTP 502**、2 通目（無害な「こんにちは」）→ **turnstile verification failed**。

## 原因
- **502**: Gemini への `fetch` が **throw**（ネットワーク／エッジのサブリクエスト timeout 等）すると未捕捉で Cloudflare の生 502（HTML・非 JSON）になり、クライアントは本文をパースできず汎用の `HTTP 502` を表示（サーバの明示的 JSON 502 はフレンドリー文言を返すので別物 → 生 502 = 未捕捉 throw と確定）。ローカル `workerd`（turnstile 検証＋KV＋インジェクション拒否を含む全経路）では **200** を確認済みで、サーバコード自体は正常。環境要因（Gemini 側の一時障害／キー）を握りつぶさず graceful に返す。
- **turnstile 401**: Turnstile トークンは**単回使用**で、サーバは検証時に消費する。送信が失敗してもトークンは消費済みだが、`onError` で `reset()` を呼んでいなかったため、次メッセージが**消費済みトークンを再利用**して 401 になっていた（1 通目の 502 が誘発）。

## 修正
- `functions/api/chat.ts`: 上流 `fetch` を `try/catch` で囲み、throw 時は `code=upstream_unreachable` の**フレンドリーな JSON 502** を返す（生 502 を出さない／`detail` に実エラーを格納）。
- `src/components/chat/ChatWidget.tsx`: `onError` でも `reset()` を呼び、失敗後の次メッセージが**新しいトークン**を取得できるようにする（成功時 `onDone` だけでなく）。

## テスト計画
- [x] typecheck / lint green、unit **114 passed**
- [x] ローカル `wrangler pages dev`（実 workerd）で全経路ストリーミング 200（実 Turnstile siteverify＋KV＋インジェクション拒否を確認）
- [ ] デプロイ後、本番でチャット送信が成功すること（一時障害なら解消・再送も新トークンで成功）。万一まだ失敗する場合は friendly 文言＋Network の `detail` で Gemini 側要因（本番 `GEMINI_API_KEY`）を切り分け。