### PR TITLE
feat(seo): キーワード最適化＋FAQPage 構造化データ＋画像alt

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -6,27 +6,35 @@
     <meta name="theme-color" content="#fbf9f4" />
     <meta
       name="description"
-      content="shiyow — AI エンジニア。LLM アプリ・AI エージェント・ML をプロダクトとして実装します。サイト内では自作のクローン AI と話せます。"
+      content="生成AI・LLMアプリ・AIエージェント・RAG・機械学習をプロダクトに実装するAIエンジニア shiyow（しよを）のポートフォリオ。ハッカソン優秀賞のAstralyx、クマ出没情報AIのFASTBEAR ほか。自作のクローンAI（Gemini製）と対話できます。"
     />
-    <meta property="og:title" content="Shiyow — AI Engineer" />
+    <meta
+      name="keywords"
+      content="AIエンジニア, AIエンジニア ポートフォリオ, ポートフォリオ, 生成AI, LLM, LLMアプリ開発, RAG, AIエージェント, 機械学習, Gemini, PyTorch, 強化学習, 会津大学, shiyow"
+    />
+    <meta name="author" content="Shiyow（しよを）" />
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1" />
+    <meta property="og:title" content="Shiyow（しよを）｜ AIエンジニア ポートフォリオ" />
     <meta
       property="og:description"
-      content="LLM アプリ・AI エージェント・ML をプロダクトとして実装する AI エンジニア。自作のクローン AI と話せるポートフォリオ。"
+      content="生成AI・LLMアプリ・AIエージェント・RAG・機械学習をプロダクトに実装するAIエンジニア。自作のクローンAIと話せるポートフォリオ。"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://shiyow.dev/" />
     <meta property="og:site_name" content="shiyow.dev" />
     <meta property="og:locale" content="ja_JP" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Shiyow — AI Engineer" />
+    <meta name="twitter:title" content="Shiyow（しよを）｜ AIエンジニア ポートフォリオ" />
     <meta
       name="twitter:description"
-      content="LLM アプリ・AI エージェント・ML を実装する AI エンジニア。自作のクローン AI と話せるポートフォリオ。"
+      content="生成AI・LLMアプリ・AIエージェント・RAG・機械学習をプロダクトに実装するAIエンジニア。自作のクローンAIと話せるポートフォリオ。"
     />
     <meta property="og:image" content="https://shiyow.dev/og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="shiyow（しよを）— AIエンジニア ポートフォリオ" />
     <meta name="twitter:image" content="https://shiyow.dev/og.png" />
+    <meta name="twitter:image:alt" content="shiyow（しよを）— AIエンジニア ポートフォリオ" />
     <link rel="canonical" href="https://shiyow.dev/" />
     <script type="application/ld+json">
       {
@@ -44,7 +52,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700;900&family=JetBrains+Mono:wght@400;500;700&display=swap"
     />
-    <title>Shiyow — AI Engineer</title>
+    <title>Shiyow（しよを）｜ AIエンジニア ポートフォリオ｜LLM・生成AI・RAG</title>
   </head>
   <body>
     <div id="root"></div>

--- a/app/src/lib/seo/renderStatic.test.ts
+++ b/app/src/lib/seo/renderStatic.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   buildSite,
   escapeHtml,
+  FAQ,
   renderBodyHtml,
   renderJsonLd,
   renderSitemap,
@@ -53,6 +54,17 @@ describe('renderBodyHtml', () => {
   it('does not hide content with display:none (cloaking guard)', () => {
     expect(body).not.toMatch(/display\s*:\s*none/i);
   });
+
+  it('places high-value JP keywords verbatim (keyword optimization)', () => {
+    for (const kw of ['AIエンジニア', '生成AI', '機械学習', 'ポートフォリオ', 'LLMアプリ']) {
+      expect(body).toContain(kw);
+    }
+  });
+
+  it('renders the FAQ questions and an image with alt text', () => {
+    for (const f of FAQ) expect(body).toContain(escapeHtml(f.q));
+    expect(body).toMatch(/<img[^>]*\salt="[^"]+"/);
+  });
 });
 
 describe('renderJsonLd', () => {
@@ -80,13 +92,25 @@ describe('renderJsonLd', () => {
     }
   });
 
-  it('carries the enriched Person fields', () => {
+  it('carries the enriched Person fields incl. an image', () => {
     const person = (graph['@graph'] as Array<Record<string, unknown>>).find(
       (n) => n['@type'] === 'Person',
     )!;
     expect(person.alumniOf).toBeTruthy();
     expect(person.worksFor).toBeTruthy();
     expect(Array.isArray(person.knowsAbout)).toBe(true);
+    expect(person.image).toBeTruthy();
+  });
+
+  it('includes a FAQPage whose questions match the FAQ source', () => {
+    const faq = (graph['@graph'] as Array<Record<string, unknown>>).find(
+      (n) => n['@type'] === 'FAQPage',
+    );
+    expect(faq).toBeTruthy();
+    const questions = faq!.mainEntity as Array<Record<string, unknown>>;
+    expect(questions).toHaveLength(FAQ.length);
+    expect(questions[0]!['@type']).toBe('Question');
+    expect((questions[0]!.acceptedAnswer as Record<string, unknown>)['@type']).toBe('Answer');
   });
 });
 

--- a/app/src/lib/seo/renderStatic.ts
+++ b/app/src/lib/seo/renderStatic.ts
@@ -26,12 +26,43 @@ export interface SeoSite {
   url: string;
   location: string;
   tagline: string;
+  /** Keyword-rich, grounded summary placed in the body and Person.description. */
+  about: string;
+  /** Target search keywords (verbatim) for meta + knowsAbout reinforcement. */
+  keywords: string[];
+  /** Root-relative avatar/representative image, e.g. "/characters/shiyow.png". */
+  image: string;
   sameAs: string[];
   knowsAbout: string[];
   alumniOf: string;
   worksFor: string;
   techStack: Profile['techStack'];
 }
+
+/** Grounded Q&A for FAQPage schema — what AI answer engines lift and cite. */
+export interface FaqEntry {
+  q: string;
+  a: string;
+}
+
+export const FAQ: FaqEntry[] = [
+  {
+    q: 'shiyow（しよを）はどんな人ですか？',
+    a: '生成AI・LLMアプリ・AIエージェント・RAG・機械学習をプロダクトとして実装するAIエンジニアです。会津大学大学院で長文脈LLM推論（KVキャッシュ効率化）を研究しています。',
+  },
+  {
+    q: 'shiyow の代表的な作品・実績は？',
+    a: 'YouTube視聴履歴を3D可視化しAIが分析するAstralyxでハッカソン優秀賞を受賞。クマ出没情報をAIが自動収集するFASTBEAR、RAGチャットボットのDM-AIなど、生成AIプロダクトを個人・チームで開発しています。',
+  },
+  {
+    q: 'shiyow が使える技術・スキルは？',
+    a: 'Gemini / Vertex AI、LangGraph、RAG（pgvector）、Function Calling、PyTorch、強化学習（PPO）、Python・TypeScript・Go などで、LLMアプリ・AIエージェント・機械学習をプロダクト実装できます。',
+  },
+  {
+    q: 'shiyow への連絡・採用の問い合わせ方法は？',
+    a: 'ポートフォリオサイト shiyow.dev の問い合わせフォーム、またはGitHub・X から連絡できます。サイト内の自作クローンAI（Gemini製）に質問することもできます。',
+  },
+];
 
 /** Site identity for the static render — derived from PROFILE plus authored copy. */
 export function buildSite(profile: Profile): SeoSite {
@@ -42,11 +73,39 @@ export function buildSite(profile: Profile): SeoSite {
     url: 'https://shiyow.dev/',
     location: profile.location,
     tagline:
-      'LLM アプリ・AI エージェント・ML をプロダクトとして実装する AI エンジニア。自作のクローン AI と話せるポートフォリオ。',
+      'LLMアプリ・AIエージェント・機械学習をプロダクトとして実装するAIエンジニア。自作のクローンAIと話せるポートフォリオ。',
+    about:
+      'shiyow（しよを）は、生成AI・LLMアプリ・AIエージェント・RAG・機械学習をプロダクトとして実装するAIエンジニアです。' +
+      '会津大学大学院で長文脈LLM推論（KVキャッシュ効率化）を研究しながら、ハッカソン優秀賞のAstralyxや、クマ出没情報を' +
+      'AIが自動収集するFASTBEARなど、生成AIプロダクトを個人・チームで開発してきました。このポートフォリオサイトでは、' +
+      'モデル選定からコスト最適化・本番デプロイまで一人で通せる実装力の例として、自作のクローンAI（Gemini製）と対話できます。',
+    keywords: [
+      'AIエンジニア',
+      'AIエンジニア ポートフォリオ',
+      'ポートフォリオ',
+      '生成AI',
+      'LLM',
+      'LLMアプリ開発',
+      'AIエージェント',
+      'RAG',
+      '機械学習',
+      'Gemini',
+      'PyTorch',
+      '強化学習',
+      '会津大学',
+      'shiyow',
+    ],
+    image: '/characters/shiyow.png',
     sameAs: ['https://github.com/shiyow5', 'https://x.com/twinS_KNSN1415'],
     knowsAbout: [
+      'AIエンジニア',
+      '生成AI',
+      'LLMアプリ開発',
+      'AIエージェント開発',
+      '機械学習',
       'LLM',
       'RAG',
+      'Retrieval-Augmented Generation',
       'AI Agents',
       'Machine Learning',
       'Reinforcement Learning',
@@ -154,6 +213,10 @@ export function renderBodyHtml(site: SeoSite, works: Work[], activities: Activit
     .map((u) => `<a href="${escapeHtml(u)}">${escapeHtml(u)}</a>`)
     .join(' · ');
 
+  const faqHtml = FAQ.map(
+    (f) => `<article><h3>${escapeHtml(f.q)}</h3><p>${escapeHtml(f.a)}</p></article>`,
+  ).join('');
+
   const style =
     'max-width:880px;margin:0 auto;padding:2.5rem 1.25rem;' +
     "font-family:system-ui,-apple-system,'Segoe UI',sans-serif;" +
@@ -162,13 +225,16 @@ export function renderBodyHtml(site: SeoSite, works: Work[], activities: Activit
   return (
     `<div id="seo-prerender" style="${style}">` +
     `<header>` +
-    `<h1>${escapeHtml(site.name)} — ${escapeHtml(site.role)}</h1>` +
+    `<img src="${escapeHtml(site.image)}" alt="${escapeHtml(site.name)}（AIエンジニア / AI Engineer）のアイコン" width="96" height="96" style="display:block;margin-bottom:0.75rem" />` +
+    `<h1>${escapeHtml(site.name)}（しよを）— AIエンジニア / AI Engineer</h1>` +
     `<p>${escapeHtml(site.tagline)}</p>` +
+    `<p>${escapeHtml(site.about)}</p>` +
     `<p>${escapeHtml(site.location)}</p>` +
     `</header>` +
-    `<section><h2>Works</h2>${worksHtml}</section>` +
-    `<section><h2>Activity</h2><ol>${activitiesHtml}</ol></section>` +
-    `<section><h2>Tech Stack</h2><dl>${stackHtml}</dl></section>` +
+    `<section><h2>作品 (Works)</h2>${worksHtml}</section>` +
+    `<section><h2>経歴・活動 (Activity)</h2><ol>${activitiesHtml}</ol></section>` +
+    `<section><h2>技術スタック (Tech Stack)</h2><dl>${stackHtml}</dl></section>` +
+    `<section><h2>よくある質問 (FAQ)</h2>${faqHtml}</section>` +
     `<footer><p>${sameAsHtml}</p></footer>` +
     `</div>`
   );
@@ -191,13 +257,25 @@ export function renderJsonLd(site: SeoSite, works: Work[]): JsonLdNode {
     '@type': 'Person',
     '@id': personId,
     name: site.name,
-    jobTitle: site.role,
-    description: site.tagline,
+    alternateName: 'しよを',
+    jobTitle: 'AIエンジニア / AI Engineer',
+    description: site.about,
     url: site.url,
+    image: `${origin(site.url)}${site.image}`,
     knowsAbout,
     alumniOf: { '@type': 'CollegeOrUniversity', name: site.alumniOf },
     worksFor: { '@type': 'Organization', name: site.worksFor },
     sameAs: site.sameAs,
+  };
+
+  const faqPage: JsonLdNode = {
+    '@type': 'FAQPage',
+    '@id': `${site.url}#faq`,
+    mainEntity: FAQ.map((f) => ({
+      '@type': 'Question',
+      name: f.q,
+      acceptedAnswer: { '@type': 'Answer', text: f.a },
+    })),
   };
 
   const website: JsonLdNode = {
@@ -240,7 +318,7 @@ export function renderJsonLd(site: SeoSite, works: Work[]): JsonLdNode {
 
   return {
     '@context': 'https://schema.org',
-    '@graph': [person, website, itemList, ...creativeWorks],
+    '@graph': [person, website, faqPage, itemList, ...creativeWorks],
   };
 }
 


### PR DESCRIPTION
## 背景
外部診断が **総合 62/100（前回 36 から改善）／技術的SEO 38・キーワード 65・AI引用 58%・LLMO 70** を提示。低評価の主因として「構造化データが分類されにくい」「画像 alt / meta 不足」「検索キーワードが見出し・説明文に体系配置されていない」を指摘。

ライブ HTML を実測したところ、**`AIエンジニア`／`生成AI`／`機械学習` が 0 回**（"AI エンジニア"・"ML" など別表記のみ）、プリレンダ本文に `<img>` ゼロ、JSON-LD は `@graph` のみ（FAQ なし）というギャップを確認 → 対応。

## 変更
- **キーワード最適化**: `title`／`description`／`keywords`／`author`／`robots` メタを整備。本文に H1「Shiyow（しよを）— AIエンジニア / AI Engineer」、**接地済み About 段落**、二言語見出し（作品 / 経歴・活動 / 技術スタック）を追加。
  → 実 HTML で `AIエンジニア` 0→19・`生成AI` 0→14・`機械学習` 0→12・`LLMアプリ` 0→12。
- **FAQPage 構造化データ**: 接地済み Q&A 4件（人物 / 実績 / スキル / 連絡）を JSON-LD `@graph` に追加。**AI 回答エンジンが引用しやすい形**にして AI引用可能性・LLMO を底上げ。
- **Person 強化**: `image`（アバター）・`alternateName`「しよを」・`jobTitle`「AIエンジニア / AI Engineer」・キーワード豊富な `description`。
- **画像 alt**: プリレンダ本文にプロフィール画像（`alt` 付き）を追加（非JSクローラはこれまで `img` ゼロ）。React 側の `img` は既に `alt` 付きで JS クローラは充足済み。

すべて既存データ（works/activity/profile）に**接地**しており、新規事実の捏造はなし。

## テスト計画
- [x] 純関数回帰テスト 16（+3: キーワード verbatim／FAQ・img alt／FAQPage・Person.image）
- [x] 全 unit **117 passed**・typecheck/lint/format green
- [x] e2e smoke 3/3（マウント後にフォールバック置換＝UX 非退行）
- [x] dist 検証: JSON-LD **13 ノード**（Person/WebSite/FAQPage/ItemList/CreativeWork×9）妥当、キーワード/FAQ/img alt 出力を確認
- [ ] デプロイ後、診断ツール再計測 & Google Rich Results Test で FAQPage 認識を確認