### PR TITLE
feat(llmo): llms.txt・セキュリティヘッダ・BreadcrumbList・内部リンク 強化

### DIFF
--- a/app/public/_headers
+++ b/app/public/_headers
@@ -1,0 +1,7 @@
+# Cloudflare Pages response headers (applied at the edge to every response).
+/*
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()

--- a/app/scripts/prerender.mjs
+++ b/app/scripts/prerender.mjs
@@ -28,7 +28,9 @@ const dataDir = join(appRoot, 'src', 'data');
 const renderSrc = readFileSync(join(appRoot, 'src/lib/seo/renderStatic.ts'), 'utf8');
 const { code } = await transform(renderSrc, { loader: 'ts', format: 'esm' });
 const renderUrl = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`;
-const { buildSite, renderBodyHtml, renderJsonLd, renderSitemap } = await import(renderUrl);
+const { buildSite, renderBodyHtml, renderJsonLd, renderSitemap, renderLlmsTxt } = await import(
+  renderUrl
+);
 
 const readJson = (name) => JSON.parse(readFileSync(join(dataDir, name), 'utf8'));
 const profile = readJson('profile.json');
@@ -63,9 +65,10 @@ html = html.replace(
 
 writeFileSync(indexPath, html);
 
-// 3. Sitemap (single URL today; lastmod = build date).
+// 3. Sitemap (single URL today; lastmod = build date) + llms.txt digest.
 const lastmod = new Date().toISOString().slice(0, 10);
 writeFileSync(join(distDir, 'sitemap.xml'), renderSitemap([{ loc: site.url, lastmod }]));
+writeFileSync(join(distDir, 'llms.txt'), renderLlmsTxt(site, works, activities));
 
 // 4. Sanity gate: the rendered HTML must actually contain every work title.
 for (const w of works) {
@@ -77,5 +80,5 @@ for (const w of works) {
 const graphNodes = graph['@graph'].length;
 console.log(
   `prerender: baked ${works.length} works + ${activities.length} activities, ` +
-    `JSON-LD @graph (${graphNodes} nodes), and sitemap.xml into dist/`,
+    `JSON-LD @graph (${graphNodes} nodes), sitemap.xml and llms.txt into dist/`,
 );

--- a/app/src/lib/seo/renderStatic.test.ts
+++ b/app/src/lib/seo/renderStatic.test.ts
@@ -5,6 +5,7 @@ import {
   FAQ,
   renderBodyHtml,
   renderJsonLd,
+  renderLlmsTxt,
   renderSitemap,
   workUrl,
 } from './renderStatic';
@@ -65,6 +66,15 @@ describe('renderBodyHtml', () => {
     for (const f of FAQ) expect(body).toContain(escapeHtml(f.q));
     expect(body).toMatch(/<img[^>]*\salt="[^"]+"/);
   });
+
+  it('emits section anchors, an internal nav, lazy images and tech lists', () => {
+    for (const id of ['works', 'activity', 'tech', 'faq']) {
+      expect(body).toContain(`id="${id}"`);
+      expect(body).toContain(`href="#${id}"`); // internal nav link
+    }
+    expect(body).toContain('loading="lazy"');
+    expect(body).toMatch(/<ul class="tech">/);
+  });
 });
 
 describe('renderJsonLd', () => {
@@ -111,6 +121,25 @@ describe('renderJsonLd', () => {
     expect(questions).toHaveLength(FAQ.length);
     expect(questions[0]!['@type']).toBe('Question');
     expect((questions[0]!.acceptedAnswer as Record<string, unknown>)['@type']).toBe('Answer');
+  });
+
+  it('includes a BreadcrumbList', () => {
+    const crumb = (graph['@graph'] as Array<Record<string, unknown>>).find(
+      (n) => n['@type'] === 'BreadcrumbList',
+    );
+    expect(crumb).toBeTruthy();
+    expect((crumb!.itemListElement as unknown[]).length).toBeGreaterThan(1);
+  });
+});
+
+describe('renderLlmsTxt', () => {
+  const txt = renderLlmsTxt(site, WORKS, ACTIVITIES);
+
+  it('is a Markdown digest covering works, FAQ and links', () => {
+    expect(txt.startsWith('# ')).toBe(true);
+    for (const w of WORKS) expect(txt).toContain(w.title);
+    for (const f of FAQ) expect(txt).toContain(f.q);
+    for (const u of site.sameAs) expect(txt).toContain(u);
   });
 });
 

--- a/app/src/lib/seo/renderStatic.ts
+++ b/app/src/lib/seo/renderStatic.ts
@@ -184,7 +184,9 @@ export function renderBodyHtml(site: SeoSite, works: Work[], activities: Activit
   const worksHtml = works
     .map((w) => {
       const tech =
-        w.tech.length > 0 ? `<p class="tech">Tech: ${escapeHtml(w.tech.join(', '))}</p>` : '';
+        w.tech.length > 0
+          ? `<ul class="tech">${w.tech.map((t) => `<li>${escapeHtml(t)}</li>`).join('')}</ul>`
+          : '';
       return (
         `<article id="work-${escapeHtml(w.id)}">` +
         `<h3>${escapeHtml(w.title)}</h3>` +
@@ -225,16 +227,26 @@ export function renderBodyHtml(site: SeoSite, works: Work[], activities: Activit
   return (
     `<div id="seo-prerender" style="${style}">` +
     `<header>` +
-    `<img src="${escapeHtml(site.image)}" alt="${escapeHtml(site.name)}（AIエンジニア / AI Engineer）のアイコン" width="96" height="96" style="display:block;margin-bottom:0.75rem" />` +
+    `<img src="${escapeHtml(site.image)}" alt="${escapeHtml(site.name)}（AIエンジニア / AI Engineer）のアイコン" width="96" height="96" loading="lazy" style="display:block;margin-bottom:0.75rem" />` +
     `<h1>${escapeHtml(site.name)}（しよを）— AIエンジニア / AI Engineer</h1>` +
     `<p>${escapeHtml(site.tagline)}</p>` +
     `<p>${escapeHtml(site.about)}</p>` +
     `<p>${escapeHtml(site.location)}</p>` +
+    `<nav aria-label="目次"><ul>` +
+    `<li><a href="#works">作品 (Works)</a></li>` +
+    `<li><a href="#activity">経歴・活動 (Activity)</a></li>` +
+    `<li><a href="#tech">技術スタック (Tech Stack)</a></li>` +
+    `<li><a href="#faq">よくある質問 (FAQ)</a></li>` +
+    `</ul></nav>` +
     `</header>` +
-    `<section><h2>作品 (Works)</h2>${worksHtml}</section>` +
-    `<section><h2>経歴・活動 (Activity)</h2><ol>${activitiesHtml}</ol></section>` +
-    `<section><h2>技術スタック (Tech Stack)</h2><dl>${stackHtml}</dl></section>` +
-    `<section><h2>よくある質問 (FAQ)</h2>${faqHtml}</section>` +
+    `<section id="works"><h2>作品 (Works)</h2>` +
+    `<p>AIエンジニアとして個人・チームで開発した、生成AI・LLM・機械学習の代表作です。</p>${worksHtml}</section>` +
+    `<section id="activity"><h2>経歴・活動 (Activity)</h2>` +
+    `<p>会津大学・大学院での研究、インターン、受賞・公開を時系列でまとめています。</p><ol>${activitiesHtml}</ol></section>` +
+    `<section id="tech"><h2>技術スタック (Tech Stack)</h2>` +
+    `<p>生成AI・LLMアプリ・AIエージェント・機械学習をプロダクト実装する主な技術です。</p><dl>${stackHtml}</dl></section>` +
+    `<section id="faq"><h2>よくある質問 (FAQ)</h2>` +
+    `<p>shiyow（しよを）についてよく聞かれる質問への回答です。</p>${faqHtml}</section>` +
     `<footer><p>${sameAsHtml}</p></footer>` +
     `</div>`
   );
@@ -278,6 +290,18 @@ export function renderJsonLd(site: SeoSite, works: Work[]): JsonLdNode {
     })),
   };
 
+  const breadcrumb: JsonLdNode = {
+    '@type': 'BreadcrumbList',
+    '@id': `${site.url}#breadcrumb`,
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'ホーム', item: site.url },
+      { '@type': 'ListItem', position: 2, name: '作品', item: `${site.url}#works` },
+      { '@type': 'ListItem', position: 3, name: '経歴・活動', item: `${site.url}#activity` },
+      { '@type': 'ListItem', position: 4, name: '技術スタック', item: `${site.url}#tech` },
+      { '@type': 'ListItem', position: 5, name: 'FAQ', item: `${site.url}#faq` },
+    ],
+  };
+
   const website: JsonLdNode = {
     '@type': 'WebSite',
     '@id': `${site.url}#website`,
@@ -318,7 +342,7 @@ export function renderJsonLd(site: SeoSite, works: Work[]): JsonLdNode {
 
   return {
     '@context': 'https://schema.org',
-    '@graph': [person, website, faqPage, itemList, ...creativeWorks],
+    '@graph': [person, website, faqPage, breadcrumb, itemList, ...creativeWorks],
   };
 }
 
@@ -341,4 +365,38 @@ export function renderSitemap(entries: SitemapEntry[]): string {
     `<?xml version="1.0" encoding="UTF-8"?>\n` +
     `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}\n</urlset>\n`
   );
+}
+
+/**
+ * /llms.txt — the emerging LLMO convention: a plain-Markdown digest of the site
+ * for AI assistants. Generated from the same grounded data so it never drifts.
+ */
+export function renderLlmsTxt(site: SeoSite, works: Work[], activities: Activity[]): string {
+  const lines: string[] = [
+    `# ${site.name}（しよを）— AIエンジニア / AI Engineer`,
+    '',
+    `> ${site.tagline}`,
+    '',
+    site.about,
+    '',
+    '## Works（作品）',
+    ...works.map(
+      (w) => `- [${w.title}](${workUrl(w, site.url)})（${w.status}・${w.year}）: ${w.tagline}`,
+    ),
+    '',
+    '## Activity（経歴・活動）',
+    ...activities.map((a) => `- ${formatMonth(a.date)} ${a.title}: ${a.summary}`),
+    '',
+    '## Tech Stack（技術スタック）',
+    ...site.techStack.map((g) => `- ${g.label}: ${g.items.join(', ')}`),
+    '',
+    '## FAQ',
+    ...FAQ.flatMap((f) => [`- Q: ${f.q}`, `  A: ${f.a}`]),
+    '',
+    '## Links',
+    `- Site: ${site.url}`,
+    ...site.sameAs.map((u) => `- ${u}`),
+    '',
+  ];
+  return lines.join('\n');
 }


### PR DESCRIPTION
## 背景
外部LLMO診断（**79/100「概ね良好」**）の改善項目に対応。実サイトを検証した結果も反映:
- `/llms.txt` は**実体が無く** SPA フォールバックの 200 HTML を返していた（診断の「設置済み」は誤検出）。
- **PerplexityBot は実際には Allow 済み**（診断の「ブロック」は誤読）。GPTBot/ClaudeBot のみブロック（利用者の明示方針）。

## 変更（非対立の改善のみ）
- **llms.txt（実体）**: prerender が `dist/llms.txt` をデータから生成（概要 / Works / Activity / Tech Stack / FAQ / Links の Markdown ダイジェスト、本文と同じ接地データ）。
- **セキュリティヘッダ**: `public/_headers` を追加 — `Strict-Transport-Security` / `X-Content-Type-Options` / `X-Frame-Options` / `Referrer-Policy` / `Permissions-Policy`。Turnstile への影響回避のため COOP は付けない（診断 2/4 → 改善見込み）。
- **構造化データ**: JSON-LD に **BreadcrumbList** を追加（`@graph` 14 ノード）。
- **コンテンツ構造**: 各 `section` に `id`（works/activity/tech/faq）＋目次 `nav` の**内部リンク**、各 section 冒頭に**結論ファースト**のリード文（キーワードも補強）。
- **画像 / リスト**: プロフィール画像に `loading="lazy"`、作品の技術を `<ul>` リスト化。

## 対応しなかった項目（理由）
- **GPTBot / ClaudeBot ブロック**: 利用者の明示方針（学習系クローラ拒否）。検索/回答系（OAI-SearchBot・PerplexityBot・Claude-User 等）は許可済みで被引用は維持。スコアより方針を優先（要相談）。
- **HowTo スキーマ**: 手順解説コンテンツが無いため非該当。
- **WebP/AVIF**: 画像 1 点のみで費用対効果が小さく今回見送り。

## テスト計画
- [x] 純関数テスト 19（+3: BreadcrumbList / llms.txt / section anchors・nav・lazy・tech list）
- [x] 全 unit **120 passed**・typecheck/lint/format green・e2e smoke 3/3
- [x] dist 検証: `_headers`・`llms.txt` 生成、JSON-LD に BreadcrumbList、section id/nav/lazy 出力
- [ ] デプロイ後: `/llms.txt` が実体（200 text/plain でなく Markdown）で配信、レスポンスにセキュリティヘッダ付与を確認