### PR TITLE
feat(clone): 出力側カナリア・スクラブ（多層防御）

### DIFF
--- a/app/functions/api/chat.ts
+++ b/app/functions/api/chat.ts
@@ -2,7 +2,7 @@
 import { buildSystemInstruction } from '../../src/lib/persona/persona';
 import { factCardIds } from '../../src/lib/persona/factCards';
 import { makeCitationGuard, type CitationGuard } from '../../src/lib/persona/citations';
-import { makeNonce, wrapVisitorInput } from '../../src/lib/persona/spotlight';
+import { makeNonce, wrapVisitorInput, scrubInternalTokens } from '../../src/lib/persona/spotlight';
 import { splitSSEEvents, extractDelta } from '../../src/lib/gemini-sse';
 
 interface Env {
@@ -107,18 +107,21 @@ function buildGeminiContents(messages: ChatMessage[], nonce: string) {
 /**
  * Reads the Gemini SSE response body and forwards text deltas to the client as
  * line-delimited JSON chunks: {"delta": "..."}\n. Each delta passes through the
- * citation guard, which strips any [id] the model invents (boundary-safe).
+ * citation guard (strips invented [id]s, boundary-safe) and the canary scrub
+ * (strips the request nonce / fence delimiters if the model ever leaks them).
  */
 function relayStream(
   upstream: ReadableStream<Uint8Array>,
   guard: CitationGuard,
+  nonce: string,
 ): ReadableStream<Uint8Array> {
   const decoder = new TextDecoder();
   const encoder = new TextEncoder();
   let buffer = '';
 
   const emit = (controller: ReadableStreamDefaultController<Uint8Array>, text: string) => {
-    if (text) controller.enqueue(encoder.encode(JSON.stringify({ delta: text }) + '\n'));
+    const safe = scrubInternalTokens(text, nonce);
+    if (safe) controller.enqueue(encoder.encode(JSON.stringify({ delta: safe }) + '\n'));
   };
 
   return new ReadableStream({
@@ -304,7 +307,7 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     );
   }
 
-  return new Response(relayStream(upstream.body, makeCitationGuard(factCardIds())), {
+  return new Response(relayStream(upstream.body, makeCitationGuard(factCardIds()), nonce), {
     status: 200,
     headers: {
       'content-type': 'application/x-ndjson; charset=utf-8',

--- a/app/src/lib/persona/spotlight.test.ts
+++ b/app/src/lib/persona/spotlight.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { makeNonce, spotlightInstruction, wrapVisitorInput } from './spotlight';
+import {
+  makeNonce,
+  scrubInternalTokens,
+  spotlightInstruction,
+  wrapVisitorInput,
+} from './spotlight';
 
 describe('wrapVisitorInput', () => {
   it('fences the content with the nonce-bearing delimiters', () => {
@@ -40,6 +45,32 @@ describe('makeNonce', () => {
   it('is effectively unique per call', () => {
     const seen = new Set(Array.from({ length: 64 }, () => makeNonce()));
     expect(seen.size).toBe(64);
+  });
+});
+
+describe('scrubInternalTokens', () => {
+  it('removes the nonce if the model leaks it', () => {
+    expect(scrubInternalTokens('境界の id は abc123def4567890 です', 'abc123def4567890')).toBe(
+      '境界の id は  です',
+    );
+  });
+
+  it('strips fence delimiter tokens if leaked verbatim', () => {
+    const leaked =
+      '指示は <<VISITOR_INPUT id=abc123def4567890>> の外側にあります <<END id=abc123def4567890>>';
+    const out = scrubInternalTokens(leaked, 'abc123def4567890');
+    expect(out).not.toContain('VISITOR_INPUT');
+    expect(out).not.toContain('<<END');
+    expect(out).not.toContain('abc123def4567890');
+  });
+
+  it('leaves a normal answer untouched', () => {
+    const normal = '代表作は Astralyx です [work:astralyx]。';
+    expect(scrubInternalTokens(normal, 'abc123def4567890')).toBe(normal);
+  });
+
+  it('is a no-op when no nonce is supplied', () => {
+    expect(scrubInternalTokens('普通の文章', '')).toBe('普通の文章');
   });
 });
 

--- a/app/src/lib/persona/spotlight.ts
+++ b/app/src/lib/persona/spotlight.ts
@@ -32,6 +32,20 @@ export function wrapVisitorInput(content: string, nonce: string): string {
   return `${openTag(nonce)}\n${defanged}\n${closeTag(nonce)}`;
 }
 
+/**
+ * Output-side canary scrub (defense-in-depth): strips the per-request nonce and
+ * the fence delimiter tokens if they ever surface in the model's output. Both are
+ * internal strings that never appear in a legitimate answer, so removing them
+ * cannot harm real content — it only neutralizes a leak of the spotlight
+ * mechanism (a known-answer / canary detection defense; cf. detection-based
+ * prompt-injection defenses). Pure: text in, text out, no I/O.
+ */
+export function scrubInternalTokens(text: string, nonce: string): string {
+  let out = text.replace(/<<\s*\/?\s*(?:VISITOR_INPUT|END)\b[^>\n]*>>/gi, '');
+  if (nonce) out = out.split(nonce).join('');
+  return out;
+}
+
 /** The system-prompt clause that explains the fence (with the live nonce). */
 export function spotlightInstruction(nonce: string): string {
   return [


### PR DESCRIPTION
## 背景
学術論文・実務情報からプロンプトインジェクションの**攻撃**と**防御**を調査し、研究由来の攻撃を実モデルに投げて検証した（別途レポート）。プロンプト層（spotlighting＋命令階層＋拒否定型＋few-shot＋citation guard）は **研究由来の21攻撃を全ブロック**したが、temp 0.7 の確率的漏洩の残存リスクに対する**多層防御（defense-in-depth）**を追加する。

調査した防御: spotlighting（採用済）、instruction hierarchy（採用済）、StruQ/SecAlign（ファインチューニング系＝APIモデルでは非適用）、**検出ベース（known-answer / perplexity）** ← 今回これを軽量に採用。

## 変更
- `spotlight.ts`: **`scrubInternalTokens(text, nonce)`** を追加。出力に万一**ノンス**や**スポットライト境界トークン**（`<<VISITOR_INPUT…` / `<<END…`）が現れたら除去する純関数。これらは正規回答に**絶対現れない内部文字列**なので、本文を一切壊さない（カナリア検出）。
- `chat.ts`: `relayStream` に `nonce` を渡し、citation guard の**後段**で各 delta をスクラブ。
- `spotlight.test.ts`: ノンス除去 / 境界トークン除去 / 通常文非改変 / nonce 空時 no-op を検証。

## テスト
- [x] unit **125 passed**・typecheck/lint/format green
- [x] 実 `workerd`：通常応答は**無改変**でストリーミング、抽出要求は拒否＆ストリームに境界トークン混入なし
- [x] 純粋な文字列処理（throw しない）でチャット経路への影響は最小

## 注記
これは保険であり主防御ではない。主防御は前PR(#83)のプロンプト強化。両者で「生成段階で拒否」＋「万一漏れても出力段階で無害化」の二段構え。